### PR TITLE
encapp: avoid clobbering json files on syntax issues

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -22,5 +22,7 @@ lint: \
 		echo "processing $$file" ; \
 		rm -f ${TMPFILE}; \
 		jq --indent 4 . $$file > ${TMPFILE}; \
-		mv ${TMPFILE} $$file; \
+		if [[ $$? -eq "0" ]]; then \
+			mv ${TMPFILE} $$file; \
+		fi \
 	done


### PR DESCRIPTION
This will avoid files being completely removed when their
syntax is broken.