### PR TITLE
encapp: have script report uninstalled apps

### DIFF
--- a/scripts/encapp.py
+++ b/scripts/encapp.py
@@ -21,7 +21,7 @@ sys.path.append(SCRIPT_ROOT_DIR)
 import proto.tests_pb2 as tests_definitions  # noqa: E402
 
 
-__version__ = '1.0'
+__version__ = '1.1'
 
 
 APPNAME_MAIN = 'com.facebook.encapp'

--- a/scripts/encapp.py
+++ b/scripts/encapp.py
@@ -235,6 +235,15 @@ def install_app(serial, debug=0):
     run_cmd(f'adb -s {serial} install -g {APK_TEST}', debug)
 
 
+def install_ok(serial, debug=0):
+    package_list = installed_apps(serial, debug)
+    if APPNAME_MAIN not in package_list:
+        return False
+    if APPNAME_TEST in package_list:
+        return False
+    return True
+
+
 def uninstall_app(serial, debug=0):
     package_list = installed_apps(serial, debug)
     if APPNAME_MAIN in package_list:
@@ -650,6 +659,11 @@ def main(argv):
     # uninstall app
     if options.func == 'uninstall':
         uninstall_app(serial, options.debug)
+        sys.exit(0)
+
+    # ensure the app is correctly installed
+    assert install_ok(serial, options.debug), (
+        'Apps not installed in %s' % serial)
 
     # run function
     if options.func == 'list':

--- a/scripts/encapp.py
+++ b/scripts/encapp.py
@@ -25,7 +25,6 @@ __version__ = '1.0'
 
 
 APPNAME_MAIN = 'com.facebook.encapp'
-APPNAME_TEST = 'com.facebook.encapp.test'
 ACTIVITY = f'{APPNAME_MAIN}/.MainActivity'
 ENCAPP_OUTPUT_FILE_NAME_RE = r'encapp_.*'
 RD_RESULT_FILE_NAME = 'rd_results.json'
@@ -35,8 +34,6 @@ SCRIPT_DIR, _ = os.path.split(SCRIPT_PATH)
 APK_DIR = os.path.join(SCRIPT_DIR, '../app/build/outputs/apk')
 APK_NAME_MAIN = f'{APPNAME_MAIN}-v1.0-debug.apk'
 APK_MAIN = os.path.join(APK_DIR, 'debug', APK_NAME_MAIN)
-APK_NAME_TEST = f'{APPNAME_MAIN}-v1.0-debug-androidTest.apk'
-APK_TEST = os.path.join(APK_DIR, 'androidTest/debug', APK_NAME_TEST)
 
 FUNC_CHOICES = {
     'help': 'show help options',
@@ -232,14 +229,11 @@ def wait_for_exit(serial, debug=0):
 
 def install_app(serial, debug=0):
     run_cmd(f'adb -s {serial} install -g {APK_MAIN}', debug)
-    run_cmd(f'adb -s {serial} install -g {APK_TEST}', debug)
 
 
 def install_ok(serial, debug=0):
     package_list = installed_apps(serial, debug)
     if APPNAME_MAIN not in package_list:
-        return False
-    if APPNAME_TEST in package_list:
         return False
     return True
 
@@ -250,10 +244,6 @@ def uninstall_app(serial, debug=0):
         run_cmd(f'adb -s {serial} uninstall {APPNAME_MAIN}', debug)
     else:
         print(f'warning: {APPNAME_MAIN} not installed')
-    if APPNAME_TEST in package_list:
-        run_cmd(f'adb -s {serial} uninstall {APPNAME_TEST}', debug)
-    else:
-        print(f'warning: {APPNAME_TEST} not installed')
 
 
 def parse_pm_list_packages(stdout):


### PR DESCRIPTION
Tested:

```
$ ./scripts/encapp.py list
Traceback (most recent call last):
  File "/home/chemag/proj/encapp/./scripts/encapp.py", line 690, in <module>
    main(sys.argv)
  File "/home/chemag/proj/encapp/./scripts/encapp.py", line 665, in main
    assert install_ok(serial, options.debug), (
AssertionError: Apps not installed in ...
```