### PR TITLE
encapp: fix shebang

### DIFF
--- a/scripts/encapp.py
+++ b/scripts/encapp.py
@@ -1,4 +1,4 @@
-#!/usr/local/bin/python3
+#!/usr/bin/env python3
 
 """Python script to run ENCAPP tests on Android and collect results.
 The script will create a directory based on device model and date,


### PR DESCRIPTION
Tested:

(1) OSX (MacBook Pro):

```
bash-3.2$ ./scripts/encapp.py list
Exit from 7303
--- List of supported encoders  ---

        MediaCodec {
            name: OMX.qcom.video.encoder.avc
            type {
...
```

Requirements:

```
bash-3.2$ sudo chown -R $(whoami) /usr/local/bin /usr/local/lib /usr/local/sbin

bash-3.2$ brew install python@3.9
...

bash-3.2$ brew link --overwrite python@3.9
Linking /usr/local/Cellar/python@3.9/3.9.12... 24 symlinks created.

bash-3.2$ pip3 install protobuf
...
Collecting protobuf
  Downloading protobuf-3.19.4-cp39-cp39-macosx_10_9_x86_64.whl (961 kB)
...
```

(2) Linux:

```
./scripts/encapp.py list
Exit from 18704
--- List of supported encoders  ---

        MediaCodec {
            name: OMX.qcom.video.encoder.avc
            type {
                mime_type: video/avc
...
```