### PR TITLE
Create encapp_tool python package

### DIFF
--- a/scripts/encapp.py
+++ b/scripts/encapp.py
@@ -16,7 +16,7 @@ import time
 import datetime
 import shutil
 
-from _version import __version__
+from encapp_tool import __version__
 
 SCRIPT_DIR = os.path.abspath(os.path.dirname(__file__))
 SCRIPT_ROOT_DIR = os.path.join(SCRIPT_DIR, '..')

--- a/scripts/encapp_tool/__init__.py
+++ b/scripts/encapp_tool/__init__.py
@@ -1,0 +1,1 @@
+from ._version import __version__, __version_info__

--- a/scripts/encapp_tool/_version.py
+++ b/scripts/encapp_tool/_version.py
@@ -4,8 +4,8 @@ import os
 
 VERSION_FILE = 'app/build.gradle'
 VERSION_TAG = 'versionName \"([0-9]*).([0-9]*)\"'
-SCRIPT_DIR = os.path.abspath(os.path.dirname(__file__))
-ROOT_DIR = os.path.join(SCRIPT_DIR, '..')
+SCRIPT_DIR = os.path.join(os.path.abspath(os.path.dirname(__file__)), "..")
+ROOT_DIR = os.path.join(SCRIPT_DIR, "..")
 
 
 def lookupVersion():

--- a/scripts/encapp_tool/_version.py
+++ b/scripts/encapp_tool/_version.py
@@ -1,21 +1,29 @@
 #!/usr/bin/env python3
-import re
 import os
+import re
+from typing import Optional, Tuple
 
 VERSION_FILE = 'app/build.gradle'
-VERSION_TAG = 'versionName \"([0-9]*).([0-9]*)\"'
+VERSION_TAG = r'versionName "([0-9]*).([0-9]*)"'
 SCRIPT_DIR = os.path.join(os.path.abspath(os.path.dirname(__file__)), "..")
 ROOT_DIR = os.path.join(SCRIPT_DIR, "..")
 
 
-def lookupVersion():
-    with open(f'{ROOT_DIR}/{VERSION_FILE}', 'r') as fl:
+def _lookup_expected_encapp_version() -> Optional[Tuple[str, str]]:
+    """Get encapp apk expected version from local gradle
+
+    Returns:
+        A tuple with apk version (major_version, minor_version)
+        if found, else None
+    """
+    with open(f"{ROOT_DIR}/{VERSION_FILE}", "r") as fl:
         data = fl.read()
 
     m = re.search(VERSION_TAG, data)
     if m is not None and len(m.groups()) == 2:
-        return (m.group(1), m.group(2))
+        return m.group(1), m.group(2)
+    return None
 
 
-__version_info__ = lookupVersion()
+__version_info__ = _lookup_expected_encapp_version()
 __version__ = '.'.join((str(i) for i in __version_info__))


### PR DESCRIPTION
Create python package called encapp_tool inside scripts to do refactoring and cleanup of encapp scripts.

Include private version module on encapp_tool package and share version variables