### PR TITLE
encapp: move adb commands to encapp_tool package

### DIFF
--- a/scripts/encapp.py
+++ b/scripts/encapp.py
@@ -6,7 +6,6 @@ and save encoded video and rate distortion results in the directory
 """
 
 import os
-import subprocess
 import humanfriendly
 import json
 import sys
@@ -17,6 +16,7 @@ import datetime
 import shutil
 
 from encapp_tool import __version__
+from encapp_tool.adb_cmds import run_cmd, ENCAPP_OUTPUT_FILE_NAME_RE, get_device_info, remove_files_using_regex
 
 SCRIPT_DIR = os.path.abspath(os.path.dirname(__file__))
 SCRIPT_ROOT_DIR = os.path.join(SCRIPT_DIR, '..')
@@ -26,7 +26,6 @@ import proto.tests_pb2 as tests_definitions  # noqa: E402
 
 APPNAME_MAIN = 'com.facebook.encapp'
 ACTIVITY = f'{APPNAME_MAIN}/.MainActivity'
-ENCAPP_OUTPUT_FILE_NAME_RE = r'encapp_.*'
 RD_RESULT_FILE_NAME = 'rd_results.json'
 
 SCRIPT_PATH = os.path.realpath(__file__)
@@ -127,83 +126,11 @@ R_FRAME_RATE_MAP = {
 }
 
 
-def run_cmd(cmd, debug=0):
-    ret = True
-    try:
-        if debug > 0:
-            print(cmd, sep=' ')
-        process = subprocess.Popen(cmd, shell=True,  # noqa: P204
-                                   stdout=subprocess.PIPE,
-                                   stderr=subprocess.PIPE)
-        stdout, stderr = process.communicate()
-        ret = True if process.returncode == 0 else False
-    except Exception:
-        ret = False
-        print('Failed to run command: ' + cmd)
-
-    return ret, stdout.decode(), stderr.decode()
-
-
-# returns info (device model and serial number) about the device where the
-# test will be run
-def get_device_info(serial_inp, debug=0):
-    # list all available devices
-    adb_cmd = 'adb devices -l'
-    ret, stdout, stderr = run_cmd(adb_cmd, debug)
-    assert ret, 'error: failed to get adb devices'
-
-    # parse list
-    device_info = {}
-    for line in stdout.split('\n'):
-        if line == 'List of devices attached' or line == '':
-            continue
-        serial = line.split()[0]
-        item_dict = {}
-        for item in line.split()[1:]:
-            # ':' used to separate key/values
-            if ':' in item:
-                key, val = item.split(':', 1)
-                item_dict[key] = val
-        # ensure the 'model' field exists
-        if 'model' not in item_dict:
-            item_dict['model'] = 'generic'
-        device_info[serial] = item_dict
-    assert len(device_info) > 0, 'error: no devices connected'
-    if debug > 2:
-        print('available devices: %r' % device_info)
-
-    # select output device
-    serial, model = None, None
-    if serial_inp is None:
-        # if user did not select a serial_inp, make sure there is only one
-        # device available
-        assert len(device_info) == 1, (
-            'error: need to choose a device %r' % list(device_info.keys()))
-        serial = list(device_info.keys())[0]
-        model = device_info[serial]
-
-    else:
-        # if user forced a serial number, make sure it is available
-        assert serial_inp in device_info, (
-            'error: device %s not available' % serial_inp)
-        serial = serial_inp
-        model = device_info[serial]
-
-    if debug > 0:
-        print('selecting device: serial: %s model: %s' % (serial, model))
-
+def remove_encapp_gen_files(serial, debug=0):
     # remove any files that are generated in previous runs
-    adb_cmd = 'adb -s ' + serial + ' shell ls /sdcard/'
-    ret, stdout, stderr = run_cmd(adb_cmd, debug)
-    output_files = re.findall(ENCAPP_OUTPUT_FILE_NAME_RE, stdout, re.MULTILINE)
-    for file in output_files:
-        if file == '':
-            continue
-        # remove the output
-        adb_cmd = 'adb -s ' + serial + ' shell rm /sdcard/' + file
-        run_cmd(adb_cmd, debug)
-
-    return model, serial
+    regex_str = ENCAPP_OUTPUT_FILE_NAME_RE
+    location = '/sdcard/'
+    remove_files_using_regex(serial, regex_str, location, debug)
 
 
 def wait_for_exit(serial, debug=0):
@@ -347,11 +274,13 @@ def run_codec_tests_file(test_def, model, serial, workdir, settings):
         tests.ParseFromString(fd.read())
     return run_codec_tests(tests, model, serial, workdir, settings)
 
+
 def abort_test(workdir, message):
     print('\n*** Test failed ***')
     print(message)
     shutil.rmtree(workdir)
     exit(0)
+
 
 def run_codec_tests(tests, model, serial, workdir, settings):
     test_def = settings['configfile']  # todo: check
@@ -441,8 +370,8 @@ def run_codec_tests(tests, model, serial, workdir, settings):
 
 
 def list_codecs(serial, model, debug=0):
-    adb_cmd = f'adb -s {serial} shell am start '\
-              f'-e ui_hold_sec 3 '\
+    adb_cmd = f'adb -s {serial} shell am start ' \
+              f'-e ui_hold_sec 3 ' \
               f'-e list_codecs a {ACTIVITY}'
 
     run_cmd(adb_cmd, debug)
@@ -684,6 +613,8 @@ def main(argv):
 
     # get model and serial number
     model, serial = get_device_info(options.serial, options.debug)
+    remove_encapp_gen_files(serial, options.debug)
+
     # TODO(chema): fix this
     if type(model) is dict:
         if 'model' in model:

--- a/scripts/encapp_quality.py
+++ b/scripts/encapp_quality.py
@@ -13,7 +13,7 @@ from argparse import RawTextHelpFormatter
 import re
 
 from os.path import exists
-from encapp import run_cmd
+from encapp_tool.adb_cmds import run_cmd
 from encapp import convert_to_bps
 
 PSNR_RE = "average:([0-9.]*)"

--- a/scripts/encapp_tool/adb_cmds.py
+++ b/scripts/encapp_tool/adb_cmds.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+import re
+from subprocess import PIPE, Popen, SubprocessError
+from typing import Dict, Optional, Tuple
+
+ENCAPP_OUTPUT_FILE_NAME_RE = r"encapp_.*"
+
+
+def run_cmd(cmd: str, debug: int = 0) -> Tuple[bool, str, str]:
+    """Run sh command
+
+    Args:
+        cmd (str): Command string to be executed by subprocess
+        debug (int): Debug level from 0 (No debug)
+
+    Returns:
+        Tuple with boolean (True cmd execution succeeded, false otherwise)
+        stdout and stderr messages.
+    """
+    try:
+        if debug > 0:
+            print(cmd, sep=" ")
+        process = Popen(cmd, shell=True, stdout=PIPE, stderr=PIPE)  # noqa: P204
+        stdout, stderr = process.communicate()
+        ret = True if process.returncode == 0 else False
+    except SubprocessError:
+        print("Failed to run command: " + cmd)
+        return False, "", ""
+
+    return ret, stdout.decode(), stderr.decode()
+
+
+def get_device_info(serial_inp: Optional[str], debug=0) -> Tuple[Dict, str]:
+    """Get android device information for an specific device
+
+    Get device information by executing and parsing command adb devices -l,
+    if not serial input specified and only one device connected, it returns
+    that device information.If serial input device not connected or none device
+    is connected, it fails.
+
+    Args:
+        serial_inp (str): Expected serial number to analyze.
+        debug (): Debug level
+
+    Returns:
+        device_info, serial; Where device info is a map with device info
+        and serial is the serial no. of the device.
+    """
+    device_info = get_connected_devices(debug)
+    assert len(device_info) > 0, "error: no devices connected"
+    if debug > 2:
+        print(f"available devices: {device_info}")
+
+    # select output device
+    if serial_inp is None:
+        # if user did not select a serial_inp, make sure there is only one
+        # device available
+        assert len(device_info) == 1, f"error: need to choose a device [{', '.join(device_info.keys())}]"
+        serial = list(device_info.keys())[0]
+        model = device_info[serial]
+
+    else:
+        # if user forced a serial number, make sure it is available
+        assert serial_inp in device_info, f"error: device {serial_inp} not available"
+        serial = serial_inp
+        model = device_info[serial]
+
+    if debug > 0:
+        print(f"selecting device: serial: {serial} model: {model}")
+
+    return model, serial
+
+
+def remove_files_using_regex(
+    serial: str, regex_str: str, location: str, debug: int
+) -> None:
+    """Remove files from an android device specific path following regex.
+
+    Args:
+        serial (str): Android device serial no.
+        regex_str (str): Regex to match file string
+        location (str): Path/directory to analyze and remove files from
+        debug (int): Debug level
+    """
+    adb_cmd = "adb -s " + serial + " shell ls " + location
+    _, stdout, _ = run_cmd(adb_cmd, debug)
+    output_files = re.findall(regex_str, stdout, re.MULTILINE)
+    for file in output_files:
+        # remove the output
+        adb_cmd = "adb -s " + serial + " shell rm " + location + file
+        run_cmd(adb_cmd, debug)
+
+
+def get_connected_devices(debug: int) -> Dict:
+    """Get adb connected devices
+
+    Get adb connected devices info by running adb devices -l
+
+    Args:
+        debug (int): Debug level
+
+    Returns:
+        Map of found connected devices through adb, with serial no.
+        as key.
+    """
+    # list all available devices
+    adb_cmd = "adb devices -l"
+    ret, stdout, _ = run_cmd(adb_cmd, debug)
+    assert ret, "error: failed to get adb devices"
+    # parse list
+    device_info = {}
+    for line in stdout.split("\n"):
+        if line in ["List of devices attached", ""]:
+            continue
+        serial = line.split()[0]
+        item_dict = {}
+        for item in line.split()[1:]:
+            # ':' used to separate key/values
+            if ":" in item:
+                key, val = item.split(":", 1)
+                item_dict[key] = val
+        # ensure the 'model' field exists
+        if "model" not in item_dict:
+            item_dict["model"] = "generic"
+        device_info[serial] = item_dict
+    return device_info

--- a/scripts/encapp_verify.py
+++ b/scripts/encapp_verify.py
@@ -12,9 +12,10 @@ import shutil
 from datetime import datetime
 import pandas as pd
 import numpy as np
+
 import encapp as ep
 import encapp_search as es
-from encapp import run_cmd
+from encapp_tool.adb_cmds import run_cmd, get_device_info
 from encapp import convert_to_bps
 from google.protobuf import text_format
 import proto.tests_pb2 as proto
@@ -562,7 +563,9 @@ def main(argv):
             shutil.rmtree(workdir)
 
         os.mkdir(workdir)
-        model, serial = ep.get_device_info(options.serial)
+        model, serial = get_device_info(options.serial)
+        ep.remove_encapp_gen_files(serial)
+
         if type(model) is dict:
             if 'model' in model:
                 model = model.get('model')

--- a/scripts/tests/adb_cmds_unittest.py
+++ b/scripts/tests/adb_cmds_unittest.py
@@ -1,0 +1,121 @@
+import unittest
+from unittest.mock import call, patch
+
+from encapp_tool import adb_cmds
+
+ADB_DEVICES_EMPTY = "List of devices attached\n\n"
+ADB_DEVICE_VALID_ID = "1234567890abcde"
+ADB_DEVICES_ONE_DEV = (
+    "List of devices attached\n"
+    f"{ADB_DEVICE_VALID_ID}       device "
+    "usb:123456789X "
+    "product:product01 "
+    "model:MODEL_123 "
+    "device:device_01 "
+    "transport_id:8\n\n"
+)
+
+ADB_DEVICES_MULTI_DEV = (
+    "List of devices attached\n"
+    "1234567890abcde       device "
+    "usb:123456789X "
+    "product:product01 "
+    "model:MODEL_123 "
+    "device:device_01 "
+    "transport_id:8\n"
+    "abcde1234567890       device "
+    "usb:987654321X "
+    "product:product02 "
+    "device:device_02 "
+    "transport_id:9\n\n"
+)
+
+ADB_LS_ENCAPP = (
+    "Android\nDCIM\nencapp_1.txt\nmyencapp_2.txt\nenc.txt\nencapp_logs.log\n"
+)
+
+
+class TestAdbCommands(unittest.TestCase):
+    @patch("encapp_tool.adb_cmds.run_cmd")
+    def test_get_device_info_with_not_devices_shall_raise_error(self, mock_run):
+        mock_run.return_value = (True, ADB_DEVICES_EMPTY, "")
+        with self.assertRaises(AssertionError) as exc:
+            adb_cmds.get_device_info(ADB_DEVICE_VALID_ID, debug=0)
+        self.assertEqual(exc.exception.__str__(), "error: no devices connected")
+
+    @patch("encapp_tool.adb_cmds.run_cmd")
+    def test_get_device_info_with_found_device_shall_return_info(self, mock_run):
+        mock_run.return_value = (True, ADB_DEVICES_MULTI_DEV, "")
+        expected_result = (
+            {
+                "device": "device_01",
+                "model": "MODEL_123",
+                "product": "product01",
+                "transport_id": "8",
+                "usb": "123456789X",
+            },
+            "1234567890abcde",
+        )
+        actual_result = adb_cmds.get_device_info(ADB_DEVICE_VALID_ID, debug=0)
+        self.assertEqual(expected_result, actual_result)
+
+    @patch("encapp_tool.adb_cmds.run_cmd")
+    def test_get_device_info_with_missing_device_shall_raise_exception(self, mock_run):
+        mock_run.return_value = (True, ADB_DEVICES_MULTI_DEV, "")
+        with self.assertRaises(AssertionError) as exc:
+            adb_cmds.get_device_info("not_connected_device", debug=0)
+        self.assertEqual(
+            exc.exception.__str__(), "error: device not_connected_device not available"
+        )
+
+    @patch("encapp_tool.adb_cmds.run_cmd")
+    def test_get_device_info_with_multiple_device_not_specified_return_info(
+        self, mock_run
+    ):
+        mock_run.return_value = (True, ADB_DEVICES_MULTI_DEV, "")
+        error_str = (
+            "error: need to choose a device [1234567890abcde, abcde1234567890]"
+        )
+        with self.assertRaises(AssertionError) as exc:
+            adb_cmds.get_device_info(None, debug=0)
+        self.assertEqual(exc.exception.__str__(), error_str)
+
+    @patch("encapp_tool.adb_cmds.run_cmd")
+    def test_get_device_info_with_single_device_not_specified_return_info(
+        self, mock_run
+    ):
+        mock_run.return_value = (True, ADB_DEVICES_ONE_DEV, "")
+        expected_result = (
+            {
+                "device": "device_01",
+                "model": "MODEL_123",
+                "product": "product01",
+                "transport_id": "8",
+                "usb": "123456789X",
+            },
+            "1234567890abcde",
+        )
+        actual_result = adb_cmds.get_device_info(None, debug=0)
+        self.assertEqual(expected_result, actual_result)
+
+    @patch("encapp_tool.adb_cmds.run_cmd")
+    def test_remove_files_using_regex_shall_remove_regex_match_files(self, mock_run):
+        mock_run.return_value = (True, ADB_LS_ENCAPP, "")
+        adb_cmds.remove_files_using_regex(
+            ADB_DEVICE_VALID_ID, r"encapp_.*", "/sdcard/", 1
+        )
+        mock_run.assert_has_calls(
+            [
+                call(f"adb -s {ADB_DEVICE_VALID_ID} shell ls /sdcard/", 1),
+                call(f"adb -s {ADB_DEVICE_VALID_ID} shell rm /sdcard/encapp_1.txt", 1),
+                call(f"adb -s {ADB_DEVICE_VALID_ID} shell rm /sdcard/encapp_2.txt", 1),
+                call(
+                    f"adb -s {ADB_DEVICE_VALID_ID} shell rm /sdcard/encapp_logs.log", 1
+                ),
+            ],
+            any_order=True,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Migrate functions from encapp.py scripts
to encapp_tool.adb_cmds package, added documentation
and unit test for those functions.

Signed-off-by: Hideki Mendoza <hidekim@fb.com>