### PR TITLE
encapp: grant encapp permissions and display toast if missing

### DIFF
--- a/app/src/main/java/com/facebook/encapp/MainActivity.java
+++ b/app/src/main/java/com/facebook/encapp/MainActivity.java
@@ -16,6 +16,7 @@ import android.util.Log;
 import android.view.TextureView;
 import android.view.View;
 import android.widget.TextView;
+import android.widget.Toast;
 
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.core.app.ActivityCompat;
@@ -97,7 +98,8 @@ public class MainActivity extends AppCompatActivity {
             }
             catch( android.content.ActivityNotFoundException ex) {
                 Log.e(TAG, "No activity found for handling the permission intent: " + ex.getLocalizedMessage());
-                System.exit(-1);
+                // System.exit(-1);
+                Toast.makeText(this, "Missing MANAGE_APP_ALL_FILES_ACCESS_PERMISSION request,", Toast.LENGTH_LONG).show();
             }
         }
 

--- a/scripts/encapp.py
+++ b/scripts/encapp.py
@@ -232,6 +232,18 @@ def wait_for_exit(serial, debug=0):
 
 def install_app(serial, debug=0):
     run_cmd(f'adb -s {serial} install -g {APK_MAIN}', debug)
+    grant_camera_permission(serial, debug)
+    grant_storage_permissions(serial, debug)
+    run_cmd(f'adb -s {serial} shell am force-stop -n com.facebook.encapp')
+
+
+def grant_storage_permissions(serial, debug):
+    run_cmd(f'adb -s {serial} shell pm grant {APPNAME_MAIN} android.permission.WRITE_EXTERNAL_STORAGE', debug)
+    run_cmd(f'adb -s {serial} shell pm grant {APPNAME_MAIN} android.permission.READ_EXTERNAL_STORAGE', debug)
+    run_cmd(f'adb -s {serial} shell appops set --uid {APPNAME_MAIN} MANAGE_EXTERNAL_STORAGE allow', debug)
+
+def grant_camera_permission(serial, debug):
+    run_cmd(f'adb -s {serial} shell pm grant {APPNAME_MAIN} android.permission.CAMERA', debug)
 
 
 def install_ok(serial, debug=0):


### PR DESCRIPTION
Set encapp app version to 1.5, and use display toast
if unable to start activity to grant all file access permission.

On encapp.py scripts,request encapp permission programatically
as part of installation and force-stop the app after install.