### PR TITLE
encapp: lint: Run autopep8 on all python files

### DIFF
--- a/scripts/encapp_quality.py
+++ b/scripts/encapp_quality.py
@@ -109,7 +109,9 @@ def run_quality(test_file, optionals):
         and exists(psnr_file)
         and not optionals["recalc"]
     ):
-        print("All quality indicators already calculated for media, " f"{vmaf_file}")
+        print(
+            "All quality indicators already calculated for media, "
+            f"{vmaf_file}")
     else:
         input_media_format = test.get("decoder_media_format")
         raw = True
@@ -144,7 +146,7 @@ def run_quality(test_file, optionals):
                 input_width = int(input_media_format.get("width"))
                 input_height = int(input_media_format.get("height"))
                 # If we did not get aything here use the encoded size
-            except:
+            except BaseException:
                 print("Warning. Input size if wrong.")
                 print(f"Json {input_media_format.get('width')}x"
                       f"{input_media_format.get('height')}")
@@ -266,7 +268,11 @@ def get_options(argv):
     )
 
     parser.add_argument("test", nargs="*", help="Test result in JSON format.")
-    parser.add_argument("-o", "--output", help="csv output", default="quality.csv")
+    parser.add_argument(
+        "-o",
+        "--output",
+        help="csv output",
+        default="quality.csv")
     parser.add_argument("--media", help="Media directory", default="")
     parser.add_argument(
         "--pix_fmt", help="pixel format i.e. nv12 or yuv420p", default=""
@@ -285,7 +291,10 @@ def get_options(argv):
         help="Overriden reference resolution WxH",
         default="",
     )
-    parser.add_argument("--header", help="print header to output", action="store_true")
+    parser.add_argument(
+        "--header",
+        help="print header to output",
+        action="store_true")
     parser.add_argument(
         "--fr_fr",
         help=("force full range to full range on " "distorted file"),

--- a/scripts/encapp_search.py
+++ b/scripts/encapp_search.py
@@ -93,7 +93,7 @@ def getData(options, recursive):
 
 def search(options):
     data = getData(options, not options.no_rec)
-    data['bitrate']  = data['bitrate'].apply(lambda x: convert_to_bps(x))
+    data['bitrate'] = data['bitrate'].apply(lambda x: convert_to_bps(x))
     if options.codec:
         data = data.loc[data['codec'].str.contains(options.codec)]
     if options.bitrate:

--- a/scripts/encapp_stats_to_csv.py
+++ b/scripts/encapp_stats_to_csv.py
@@ -66,21 +66,22 @@ def parse_encoding_data(json, inputfile, debug=0):
 
         data.loc[data['proctime'] < 0] = 0
         data.loc[data['duration_ms'] < 0] = 0
-        data['fps'] = round(1000.0/(data['duration_ms']), 2)
-        data['proc_fps'] = round(1000.0/(data['stop-stop_ms']), 2)
+        data['fps'] = round(1000.0 / (data['duration_ms']), 2)
+        data['proc_fps'] = round(1000.0 / (data['stop-stop_ms']), 2)
         # delete the last item
         data = data.loc[data['starttime'] > 0]
         start_ts = data.iloc[0]['starttime']
-        data['rel_start_ms'] = round((data['starttime'] - start_ts)/1000000, 2)
+        data['rel_start_ms'] = round(
+            (data['starttime'] - start_ts) / 1000000, 2)
         stop_ts = data.iloc[0]['stoptime']
-        data['rel_stop_ms'] = round((data['stoptime'] - stop_ts)/1000000, 2)
+        data['rel_stop_ms'] = round((data['stoptime'] - stop_ts) / 1000000, 2)
 
         data['start_pts_diff_ms'] = round(
-            data['rel_start_ms'] - data['pts']/1000, 2)
+            data['rel_start_ms'] - data['pts'] / 1000, 2)
         data['av_fps'] = data['fps'].rolling(
-            fps,  min_periods=fps, win_type=None).sum()/fps
+            fps, min_periods=fps, win_type=None).sum() / fps
         data['av_proc_fps'] = data['proc_fps'].rolling(
-            fps,  min_periods=fps, win_type=None).sum()/fps
+            fps, min_periods=fps, win_type=None).sum() / fps
         data['av_fps'].fillna(data['fps'], inplace=True)
         data['av_proc_fps'].fillna(data['proc_fps'], inplace=True)
         data.fillna(0, inplace=True)
@@ -116,7 +117,6 @@ def parse_decoding_data(json, inputfile, debug=0):
 
             decoded_data = decoded_data.loc[decoded_data['proctime'] >= 0]
 
-
             # oh no we may have b frames...
             decoded_data['duration_ms'] = round(
                 (decoded_data['pts'].shift(-1, axis='index', fill_value=0) -
@@ -125,29 +125,32 @@ def parse_decoding_data(json, inputfile, debug=0):
             decoded_data['fps'] = round(
                 1000.0 / (decoded_data['duration_ms']), 2)
             decoded_data['stop-stop_ms'] = round(
-            (decoded_data['stoptime'].shift(-1, axis='index', fill_value=0) -
-             decoded_data['stoptime']) / 1000000, 2)
-            decoded_data['proc_fps'] = round(1000.0/(decoded_data['stop-stop_ms']), 2)
+                (decoded_data['stoptime'].shift(-1, axis='index', fill_value=0) -
+                 decoded_data['stoptime']) / 1000000, 2)
+            decoded_data['proc_fps'] = round(
+                1000.0 / (decoded_data['stop-stop_ms']), 2)
 
             start_ts = decoded_data.iloc[0]['starttime']
-            decoded_data['rel_start_ms'] = round((decoded_data['starttime'] - start_ts)/1000000, 2)
+            decoded_data['rel_start_ms'] = round(
+                (decoded_data['starttime'] - start_ts) / 1000000, 2)
             stop_ts = decoded_data.iloc[0]['stoptime']
-            decoded_data['rel_stop_ms'] = round((decoded_data['stoptime'] - stop_ts)/1000000, 2)
+            decoded_data['rel_stop_ms'] = round(
+                (decoded_data['stoptime'] - stop_ts) / 1000000, 2)
 
             decoded_data['start_pts_diff_ms'] = round(
-                decoded_data['rel_start_ms'] - decoded_data['pts']/1000, 2)
+                decoded_data['rel_start_ms'] - decoded_data['pts'] / 1000, 2)
             decoded_data['av_fps'] = decoded_data['fps'].rolling(
-                fps,  min_periods=fps, win_type=None).sum()/fps
+                fps, min_periods=fps, win_type=None).sum() / fps
             decoded_data['av_proc_fps'] = decoded_data['proc_fps'].rolling(
-                fps,  min_periods=fps, win_type=None).sum()/fps
+                fps, min_periods=fps, win_type=None).sum() / fps
             decoded_data['av_fps'].fillna(decoded_data['fps'], inplace=True)
-            decoded_data['av_proc_fps'].fillna(decoded_data['proc_fps'], inplace=True)
+            decoded_data['av_proc_fps'].fillna(
+                decoded_data['proc_fps'], inplace=True)
             decoded_data.fillna(0)
-        
+
     except Exception as ex:
         print(f'Failed to parse decode data for {inputfile}: {ex}')
         decoded_data = None
-
 
     return decoded_data
 
@@ -162,8 +165,8 @@ def parse_gpu_data(json, inputfile, debug=0):
             gpuclock_data = pd.DataFrame(json['gpu_data']['gpu_clock_freq'])
             gpu_max_clock = int(json['gpu_data']['gpu_max_clock'])
             gpu_data['clock_perc'] = (
-                 100.0 * gpuclock_data['clock_MHz'].astype(float) /
-                 gpu_max_clock)
+                100.0 * gpuclock_data['clock_MHz'].astype(float) /
+                gpu_max_clock)
             gpu_data = gpu_data.merge(gpuclock_data)
             gpu_model = json['gpu_data']['gpu_model']
             gpu_data['source'] = inputfile
@@ -298,7 +301,7 @@ def main():
 
             fig, axs = plt.subplots(nrows=1, figsize=(12, 9), dpi=100)
             p = sb.lineplot(
-                x=encoding_data['pts']/1000000,
+                x=encoding_data['pts'] / 1000000,
                 y=encoding_data['start_pts_diff_ms'],
                 ci='sd', data=encoding_data,
                 ax=axs,
@@ -306,7 +309,7 @@ def main():
             p.set_xlabel('time (sec)')
             p.set_ylabel('frame duration (ms)')
             p = sb.lineplot(
-                x=encoding_data['pts']/1000000,
+                x=encoding_data['pts'] / 1000000,
                 y=encoding_data['duration_ms'],
                 ci='sd', data=encoding_data,
                 ax=axs,
@@ -322,7 +325,7 @@ def main():
             # plot the framerate
             fig, axs = plt.subplots(nrows=1, figsize=(12, 9), dpi=100)
             p = sb.lineplot(
-                x=encoding_data['pts']/1000000,
+                x=encoding_data['pts'] / 1000000,
                 y=encoding_data['av_proc_fps'],
                 ci='sd', data=encoding_data,
                 ax=axs,
@@ -331,7 +334,7 @@ def main():
             p.set_ylabel('framerate (fps)')
             # p.set_ylim(0, 90)
             p = sb.lineplot(  # noqa: F841
-                x=encoding_data['pts']/1000000,
+                x=encoding_data['pts'] / 1000000,
                 y=encoding_data['av_fps'],
                 ci='sd', data=encoding_data,
                 ax=axs,
@@ -355,7 +358,7 @@ def main():
 
             # p.set_ylim(0, 90)
             p = sb.lineplot(  # noqa: F841
-                x=decoded_data['pts']/1000000,
+                x=decoded_data['pts'] / 1000000,
                 y=decoded_data['av_fps'],
                 ci='sd', data=decoded_data,
                 ax=axs,

--- a/scripts/encapp_verify.py
+++ b/scripts/encapp_verify.py
@@ -437,7 +437,7 @@ def check_mean_bitrate_deviation(resultpath):
                     # Calc mean in bits per second
                     num = len(filtered)
                     if num > 0:
-                        mean = (fps * 8 * accum/num)
+                        mean = (fps * 8 * accum / num)
                     else:
                         mean = 0
                     ratio = mean / target_bitrate
@@ -467,8 +467,8 @@ def check_mean_bitrate_deviation(resultpath):
                     result_string += ('\n      {:3d}% error in {:4d}:{:4d} '
                                       '({:4d}kbps) for {:4d}kbps'
                                       .format(item[4], item[0], item[1],
-                                              int(item[3]/1000),
-                                              int(item[2]/1000)))
+                                              int(item[3] / 1000),
+                                              int(item[2] / 1000)))
                 result_string += f'\n      (limit set to {ERROR_LIMIT}%)'
             else:
                 mean_bitrate = encoder_settings.get('meanbitrate')
@@ -496,8 +496,8 @@ def check_mean_bitrate_deviation(resultpath):
                 '\n{:s} "Bitrate accuracy" {:3d} % error for '
                 '{:4d}kbps ({:4d}kbps), codec: {:s}, {:4d}p @ {:.2f} fps, {:s}'
                 .format(status,
-                        row.error, int(row.bitrate/1000),
-                        int(row.real_bitrate/1000),
+                        row.error, int(row.bitrate / 1000),
+                        int(row.real_bitrate / 1000),
                         row.codec,
                         row.height,
                         row.fps,
@@ -573,7 +573,7 @@ def main(argv):
         model, serial = get_device_info(options.serial)
         ep.remove_encapp_gen_files(serial)
 
-        if type(model) is dict:
+        if isinstance(model, dict):
             if 'model' in model:
                 model = model.get('model')
             else:

--- a/scripts/plot_frame_scores.py
+++ b/scripts/plot_frame_scores.py
@@ -101,7 +101,10 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("vfiles", nargs="+", help="VMAF Files", type=str)
     parser.add_argument("--labels", nargs="+", help="Curve labels", type=str)
-    parser.add_argument("--fig", help="Specify a file name to save figure", type=str)
+    parser.add_argument(
+        "--fig",
+        help="Specify a file name to save figure",
+        type=str)
     args = parser.parse_args()
     rd_plot = VMAFPlot()
     vmaf_files = []

--- a/scripts/plot_rd.py
+++ b/scripts/plot_rd.py
@@ -27,7 +27,7 @@ class RDPlot:
         line = self.lines[index % len(self.lines)]
         self.curve_index += 1
 
-        return color+marker+line
+        return color + marker + line
 
     def vmaf_figure(self, title):
         plt.figure()
@@ -38,7 +38,7 @@ class RDPlot:
         self.x_max = 0
         self.y_min = 100
         self.y_max = 0
-    
+
     def bitrate_figure(self, title):
         plt.figure()
         plt.title(os.path.basename(title))
@@ -58,7 +58,7 @@ class RDPlot:
         plt.legend(loc='lower right')
 
     def finish(self):
-        plt.axis([self.x_min, self.x_max+100, self.y_min-5, self.y_max])
+        plt.axis([self.x_min, self.x_max + 100, self.y_min - 5, self.y_max])
         plt.grid()
         plt.draw()
 
@@ -68,9 +68,9 @@ class RDPlot:
             data = pd.read_csv(fp)
             fp.close()
 
-            heights =  np.unique(data['height'])
-            codecs =  np.unique(data['codec'])
-           
+            heights = np.unique(data['height'])
+            codecs = np.unique(data['codec'])
+
             for height in heights:
                 filtHeight = data.loc[data['height'] == height]
                 filtHeight = filtHeight.apply(pd.to_numeric, errors='ignore')
@@ -81,18 +81,18 @@ class RDPlot:
                     filtCodec = filtHeight.loc[filtHeight['height'] == height]
                     filtHeight = filtHeight.sort_values('real_bitrate')
                     if len(filtHeight) > 0:
-                        self.draw(filtHeight['real_bitrate']/1000,
-                              filtHeight['vmaf'],
-                              f'{codec}')
+                        self.draw(filtHeight['real_bitrate'] / 1000,
+                                  filtHeight['vmaf'],
+                                  f'{codec}')
                 self.finish()
                 self.bitrate_figure(f'Bitrate accuracy for {height}p')
                 for codec in codecs:
                     filtCodec = filtHeight.loc[filtHeight['height'] == height]
                     filtHeight = filtHeight.sort_values('real_bitrate')
                     if len(filtHeight) > 0:
-                        self.draw(filtHeight['real_bitrate']/1000,
-                              filtHeight['bitrate']/1000,
-                              f'{codec}')
+                        self.draw(filtHeight['real_bitrate'] / 1000,
+                                  filtHeight['bitrate'] / 1000,
+                                  f'{codec}')
                 self.finish()
         plt.show()
 


### PR DESCRIPTION
Lint python files to conform to the PEP8 style guide

```
$ autopep8 --version
autopep8 1.6.0 (pycodestyle: 2.8.0)

$ autopep8 --in-place --aggresive scripts/*py
```