### PR TITLE
encapp: Enable continuous integration builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,45 @@
+name: build
+
+on: [push]
+
+env:
+  ADB_INSTALL_TIMEOUT: 8
+
+jobs:
+  build:
+    runs-on: macos-latest
+    strategy:
+      matrix:
+        api-level: [29]
+        python-version: ["3.6", "3.9"]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v3
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Build python
+        run: |
+          python -m pip install --upgrade pip
+          pip install pylint flake8 humanfriendly numpy pandas seaborn protobuf
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+          flake8 scripts --count --select=E9,F63,F7,F82 --exclude scripts/proto --show-source --statistics
+          flake8 scripts --exclude scripts/proto --count --exit-zero --statistics
+          pylint scripts --ignore scripts/proto --errors-only --exit-zero
+          pylint scripts --ignore scripts/proto --exit-zero
+
+      - name: Build android
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: ${{ matrix.api-level }}
+          force-avd-creation: false
+          emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+          disable-animations: true
+          script: |
+            ./gradlew build
+            adb wait-for-device shell 'while [[ -z $(getprop sys.boot_completed) ]]; do sleep 1; done; input keyevent 82'
+            python scripts/encapp.py install
+            python scripts/encapp.py list

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,25 @@
+name: tests
+
+on: [push]
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.6", "3.9"]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v3
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Pytest python
+        run: |
+          python -m pip install --upgrade pip
+          pip install pytest humanfriendly numpy pandas seaborn protobuf
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+          pytest scripts/tests

--- a/scripts/tests/test_adb_cmds_unittest.py
+++ b/scripts/tests/test_adb_cmds_unittest.py
@@ -115,7 +115,3 @@ class TestAdbCommands(unittest.TestCase):
             ],
             any_order=True,
         )
-
-
-if __name__ == "__main__":
-    unittest.main()


### PR DESCRIPTION
I'm proposing to start using some continuous integration tool. Github workflows are already integrated in github so no 3rd party service is required.

Added two jobs with some basic tests:
build: https://github.com/michalkielan/encapp/actions/runs/2444651913
test: https://github.com/michalkielan/encapp/actions/runs/2444651914

The job includes:
- Python lint:
  - `pylint` - Temporary return 0 always because of some minor failures: not used modules, not used variables etc.
  - `flake8` - The build will fail if there are some python syntax errors or undefined names.
- Pytest:
  - Run `pytest` - the unit tests filename was changed, must start with `test*` otherwise the file is not recognizable as a test.
- Android:
  - Build apk
  - Run `encapp.py`: `install` and `list` on android emulator
  
  