### PR TITLE
encapp: ci: remove adb emulator tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,9 +2,6 @@ name: build
 
 on: [push]
 
-env:
-  ADB_INSTALL_TIMEOUT: 8
-
 jobs:
   build:
     runs-on: macos-latest
@@ -35,11 +32,5 @@ jobs:
         uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: ${{ matrix.api-level }}
-          force-avd-creation: false
-          emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
-          disable-animations: true
           script: |
             ./gradlew build
-            adb wait-for-device shell 'while [[ -z $(getprop sys.boot_completed) ]]; do sleep 1; done; input keyevent 82'
-            python scripts/encapp.py install
-            python scripts/encapp.py list


### PR DESCRIPTION
Builds sometimes are failing on adb emulator, leave the ./gradle build and kill the adb tests for investigation