### PR TITLE
encapp: fix get_connected_devices to handle cr

### DIFF
--- a/scripts/encapp_tool/adb_cmds.py
+++ b/scripts/encapp_tool/adb_cmds.py
@@ -109,7 +109,7 @@ def get_connected_devices(debug: int) -> Dict:
     assert ret, "error: failed to get adb devices"
     # parse list
     device_info = {}
-    for line in stdout.split("\n"):
+    for line in stdout.splitlines():
         if line in ["List of devices attached", ""]:
             continue
         serial = line.split()[0]


### PR DESCRIPTION
Use splitlines instead of split python method to handle
CR, to fix execution error on windows hosts.