### PR TITLE
encapp: refactor encapp.py by moving install functions

### DIFF
--- a/scripts/encapp.py
+++ b/scripts/encapp.py
@@ -18,7 +18,7 @@ import shutil
 from encapp_tool import __version__
 from encapp_tool.app_utils import (
     APPNAME_MAIN, SCRIPT_DIR, ACTIVITY,
-    install_app)
+    install_app, uninstall_app, install_ok)
 from encapp_tool.adb_cmds import (
     run_cmd, ENCAPP_OUTPUT_FILE_NAME_RE, get_device_info,
     remove_files_using_regex, get_app_pid)
@@ -141,39 +141,6 @@ def wait_for_exit(serial, debug=0):
         print(f'Exit from {pid}')
     else:
         print(f'{APPNAME_MAIN} was not active')
-
-
-def install_ok(serial, debug=0):
-    package_list = installed_apps(serial, debug)
-    if APPNAME_MAIN not in package_list:
-        return False
-    return True
-
-
-def uninstall_app(serial, debug=0):
-    package_list = installed_apps(serial, debug)
-    if APPNAME_MAIN in package_list:
-        run_cmd(f'adb -s {serial} uninstall {APPNAME_MAIN}', debug)
-    else:
-        print(f'warning: {APPNAME_MAIN} not installed')
-
-
-def parse_pm_list_packages(stdout):
-    package_list = []
-    for line in stdout.split('\n'):
-        # ignore blank lines
-        if not line:
-            continue
-        if line.startswith('package:'):
-            package_list.append(line[len('package:'):])
-    return package_list
-
-
-def installed_apps(serial, debug=0):
-    ret, stdout, stderr = run_cmd(f'adb -s {serial} shell pm list packages',
-                                  debug)
-    assert ret, 'error: failed to get installed app list'
-    return parse_pm_list_packages(stdout)
 
 
 def collect_result(workdir, test_name, serial):

--- a/scripts/encapp_tool/app_utils.py
+++ b/scripts/encapp_tool/app_utils.py
@@ -29,3 +29,29 @@ def install_app(serial, debug=0):
     adb_cmds.grant_camera_permission(serial, debug)
     adb_cmds.grant_storage_permissions(serial, debug)
     adb_cmds.force_stop(serial, APPNAME_MAIN, debug)
+
+
+def install_ok(serial: str, debug=0) -> bool:
+    """Verify encapp installation at android device
+
+    Args:
+        serial (str): Android device serial no.
+        debug (int): Debug level
+
+    Returns:
+        True if encapp is installed at device, False otherwise.
+    """
+    package_list = adb_cmds.installed_apps(serial, debug)
+    if APPNAME_MAIN not in package_list:
+        return False
+    return True
+
+
+def uninstall_app(serial: str, debug=0):
+    """Uninstall encapp at android device
+
+    Args:
+        serial (str): Android device serial no.
+        debug (int): Debug level
+    """
+    adb_cmds.uninstall_apk(serial, APPNAME_MAIN, debug)

--- a/scripts/tests/unit/app_utils_test.py
+++ b/scripts/tests/unit/app_utils_test.py
@@ -6,11 +6,11 @@ from encapp_tool import app_utils
 ADB_DEVICE_VALID_ID = "1234567890abcde"
 
 
-@patch("encapp_tool.adb_cmds.install_apk")
-@patch("encapp_tool.adb_cmds.grant_storage_permissions")
-@patch("encapp_tool.adb_cmds.grant_camera_permission")
-@patch("encapp_tool.adb_cmds.force_stop")
 class TestAppUtils(unittest.TestCase):
+    @patch("encapp_tool.adb_cmds.install_apk")
+    @patch("encapp_tool.adb_cmds.grant_storage_permissions")
+    @patch("encapp_tool.adb_cmds.grant_camera_permission")
+    @patch("encapp_tool.adb_cmds.force_stop")
     def test_install_app_shall_install_encapp_apk(
         self, mock_stop, mock_perm_camera, mock_perm_store, mock_install
     ):
@@ -19,3 +19,22 @@ class TestAppUtils(unittest.TestCase):
         mock_perm_store.assert_called_with(ADB_DEVICE_VALID_ID, 0)
         mock_perm_camera.assert_called_with(ADB_DEVICE_VALID_ID, 0)
         mock_stop.assert_called_with(ADB_DEVICE_VALID_ID, "com.facebook.encapp", 0)
+
+    @patch("encapp_tool.adb_cmds.installed_apps")
+    def test_install_ok_shall_verify_if_encapp_is_installed(self, mock_apps):
+        installed_encapp = [
+            "com.android.package.a",
+            "com.facebook.encapp",
+            "com.android.package.c",
+        ]
+        not_installed_encapp = ["com.android.package.a", "com.android.package.b"]
+        mock_apps.side_effect = [installed_encapp, not_installed_encapp]
+        self.assertTrue(app_utils.install_ok(ADB_DEVICE_VALID_ID, 1))
+        self.assertFalse(app_utils.install_ok(ADB_DEVICE_VALID_ID, 1))
+
+    @patch("encapp_tool.adb_cmds.uninstall_apk")
+    def test_uninstall_app_shall_uninstall_encapp(self, mock_uninstall):
+        app_utils.uninstall_app(ADB_DEVICE_VALID_ID, 1)
+        mock_uninstall.assert_called_with(
+            ADB_DEVICE_VALID_ID, "com.facebook.encapp", 1
+        )


### PR DESCRIPTION
Moved install_ok and unistall function from encapp.py to
encapp_tool package.
Added unit test and docstring