### PR TITLE
encapp: tests: add a tests that uses B-frames

### DIFF
--- a/tests/b_frames.pbtxt
+++ b/tests/b_frames.pbtxt
@@ -1,0 +1,24 @@
+test {
+    common {
+        id: "b_frames"
+        description: "B-Frame Testing"
+    }
+    input {
+        filepath: "/tmp/akiyo_qcif.yuv"
+        resolution: "176x144"
+        pix_fmt: nv12
+        framerate: 30
+        playout_frames: 900
+    }
+    configure {
+        codec: "encoder.avc"
+        bitrate: "1000 kbps"
+        bitrate_mode: cbr
+        i_frame_interval: 2000
+        parameter {
+            key: "max-bframes"
+            type: intType
+            value: "1"
+        }
+    }
+}


### PR DESCRIPTION
From https://developer.android.com/reference/android/media/MediaFormat#KEY_MAX_B_FRAMES