### PR TITLE
encapp: fix B-frame test

### DIFF
--- a/tests/b_frames.pbtxt
+++ b/tests/b_frames.pbtxt
@@ -13,7 +13,7 @@ test {
     configure {
         codec: "encoder.avc"
         bitrate: "1000 kbps"
-        bitrate_mode: cbr
+        bitrate_mode: vbr
         i_frame_interval: 2000
         parameter {
             key: "max-bframes"


### PR DESCRIPTION
In our case, B-frame requires VBR mode.

Tested:

```
$ ffmpeg -i akiyo_qcif.y4m -f rawvideo -pix_fmt nv12 /tmp/akiyo_qcif.yuv
$ tate01 ./scripts/encapp.py run tests/b_frames.pbtxt
...
adb -s 2C21BRCC6J00T2 shell ls /sdcard/
pull encapp_377e4c44-e0b4-4383-bab4-78cc0a76f894.json to testing_PortalGo_2022-09-13_18_48/b_frames_files
pull encapp_377e4c44-e0b4-4383-bab4-78cc0a76f894.mp4 to testing_PortalGo_2022-09-13_18_48/b_frames_files
results collect: ['testing_PortalGo_2022-09-13_18_48/b_frames_files/encapp_377e4c44-e0b4-4383-bab4-78cc0a76f894.json']
```

And then:
```
$ ffmpeg -i testing_PortalGo_2022-09-13_18_48/b_frames_files/encapp_377e4c44-e0b4-4383-bab4-78cc0a76f894.mp4 -vcodec copy /tmp/foo.264
...

$ h264nal --noas-one-line /tmp/foo.264  -  |grep slice_type
        slice_type: 2
        slice_type: 0
        slice_type: 1
        slice_type: 0
        slice_type: 1
        slice_type: 0
        slice_type: 1
        slice_type: 0
        ...
```

Note the key-frame (slice_type 2), followed by P-frames (slice_type 0) and B-frames (slice_type 1).