### PR TITLE
encapp: fix encapp list command

### DIFF
--- a/scripts/encapp.py
+++ b/scripts/encapp.py
@@ -625,6 +625,8 @@ def get_options(argv):
             # remove the old value
             delattr(options, key)
     # check the validity of some parameters
+    if not options.replace:
+        options.replace = {}
     if options.replace.get('input', {}).get('filepath', ''):
         videofile = options.replace.get('input', {}).get('filepath', '')
         assert os.path.exists(videofile) and os.access(videofile, os.R_OK), (


### PR DESCRIPTION
Tested:

```
$ ./scripts/encapp.py -ddd list --device-workdir /data/data/com.facebook.encapp
adb devices -l
...
adb -s ... pull /data/data/com.facebook.encapp/codecs.txt codecs_model.txt
encoders {
  MediaCodec {
    name: c2.qti.avc.encoder
    canonical_name: c2.qti.avc.encoder
    is_alias: false
    is_encoder: true
    is_hardware_accelerated: true
    is_software_only: false
    is_vendor: true
...
```