### PR TITLE
encapp: scripts: support for enums in CLI options

### DIFF
--- a/scripts/encapp.py
+++ b/scripts/encapp.py
@@ -369,20 +369,34 @@ def update_codec_tests(test_suite, local_workdir, device_workdir, replace):
                 if (k1, k2) == ("configure", "bitrate"):
                     # already processed
                     continue
-                elif (k1 == "configure" and k2 in CONFIGURE_INT_KEYS) or (
+                # process integer keys
+                if (k1 == "configure" and k2 in CONFIGURE_INT_KEYS) or (
                     k1 == "input" and k2 in INPUT_INT_KEYS
                 ):
                     # force integer value
                     val = int(val)
-                elif (k1 == "configure" and k2 in CONFIGURE_FLOAT_KEYS) or (
+                # process float keys
+                if (k1 == "configure" and k2 in CONFIGURE_FLOAT_KEYS) or (
                     k1 == "input" and k2 in INPUT_FLOAT_KEYS
                 ):
                     # force float value
                     val = float(val)
+                # convert enum strings to integer
+                if k1 == "input" and k2 == "pix_fmt":
+                    val = tests_definitions.Input.PixFmt.Value(val)
+                if k1 == "configure" and k2 == "bitrate_mode":
+                    val = tests_definitions.Configure.BitrateMode.Value(val)
+                if k1 == "configure" and k2 == "color_standard":
+                    val = tests_definitions.Configure.ColorStandard.Value(val)
+                if k1 == "configure" and k2 == "color_range":
+                    val = tests_definitions.Configure.ColorRange.Value(val)
+                if k1 == "configure" and k2 == "color_transfer":
+                    val = tests_definitions.Configure.ColorTransfer.Value(val)
                 if not test.HasField(k1):
                     # create the Message field
                     getattr(test, k1).SetInParent()
                 setattr(getattr(test, k1), k2, val)
+
         # If no surface decode and no raw input, decode to raw
         if encapp_tool.ffutils.video_is_y4m(test.input.filepath):
             options = None


### PR DESCRIPTION
Tested:

Before:
```
$ ./scripts/encapp.py -ddd run ./tests/bitrate_buffer.pbtxt --device-workdir /data/data/com.facebook.encapp -e input.pix_fmt nv12 -i /tmp/out.nv12.yuv --codec c2.android.avc.encoder --bitrate 5Mbps --local-workdir /tmp/testadb devices -l
...
Traceback (most recent call last):
  File "/usr/lib/python3.11/site-packages/google/protobuf/internal/python_message.py", line 702, in field_setter
    new_value = type_checker.CheckValue(new_value)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/site-packages/google/protobuf/internal/type_checkers.py", line 178, in CheckValue
    raise TypeError(message)
TypeError: 'nv12' has type <class 'str'>, but expected one of: (<class 'int'>,)
...
```

After:
```
$ ~/proj/encapp/scripts/encapp.py -ddd run ~/proj/encapp/tests/bitrate_buffer.pbtxt --device-workdir /data/data/com.facebook.encapp -i ${SRC} --codec ${ENCODER} -e input.pix_fmt nv12 -e input.resolution 2688x1952 -e input.framerate 30 -e configure.bitrate_mode ${RATEMODE} --bitrate 1Mbps-31Mbps-1Mbps --local-workdir ${RESDIR}
...
results collect: ['/tmp/testing1/encapp_005e3855-41b8-443e-a29d-033de2a2ba79.json ...
...
```