### PR TITLE
encapp: added output filename to common and updated version to 1.17

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -9,7 +9,7 @@ android {
         minSdkVersion 27
         targetSdkVersion 31
         versionCode 1
-        versionName "1.16"
+        versionName "1.17"
         setProperty("archivesBaseName", applicationId + "-v" + versionName)
     }
     buildTypes {

--- a/app/src/main/java/com/facebook/encapp/utils/Statistics.java
+++ b/app/src/main/java/com/facebook/encapp/utils/Statistics.java
@@ -121,7 +121,12 @@ public class Statistics {
         mDecodingFrames = new HashMap<>(20);
         mTest = test;
         mStartDate = new Date();
-        mId = "encapp_" + UUID.randomUUID().toString();
+        // if no output filename use uuid
+        if (mTest.hasCommon() && mTest.getCommon().hasOutputFilename()) {
+            mId = mTest.getCommon().getOutputFilename();
+        } else {
+            mId = "encapp_" + UUID.randomUUID().toString();
+        }
     }
 
     public void setAppVersion(String mAppVersion) {

--- a/ios/Encapp/tests.pb.swift
+++ b/ios/Encapp/tests.pb.swift
@@ -147,6 +147,16 @@ struct Common {
   /// Clears the value of `start`. Subsequent reads from it will return its default value.
   mutating func clearStart() {self._start = nil}
 
+  /// template or specific name for output file(s)
+  var outputFilename: String {
+    get {return _outputFilename ?? String()}
+    set {_outputFilename = newValue}
+  }
+  /// Returns true if `outputFilename` has been explicitly set.
+  var hasOutputFilename: Bool {return self._outputFilename != nil}
+  /// Clears the value of `outputFilename`. Subsequent reads from it will return its default value.
+  mutating func clearOutputFilename() {self._outputFilename = nil}
+
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
   init() {}
@@ -155,6 +165,7 @@ struct Common {
   fileprivate var _description_p: String? = nil
   fileprivate var _operation: String? = nil
   fileprivate var _start: String? = nil
+  fileprivate var _outputFilename: String? = nil
 }
 
 struct Parameter {
@@ -950,6 +961,7 @@ extension Common: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBas
     2: .same(proto: "description"),
     3: .same(proto: "operation"),
     4: .same(proto: "start"),
+    5: .standard(proto: "output_filename"),
   ]
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
@@ -962,6 +974,7 @@ extension Common: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBas
       case 2: try { try decoder.decodeSingularStringField(value: &self._description_p) }()
       case 3: try { try decoder.decodeSingularStringField(value: &self._operation) }()
       case 4: try { try decoder.decodeSingularStringField(value: &self._start) }()
+      case 5: try { try decoder.decodeSingularStringField(value: &self._outputFilename) }()
       default: break
       }
     }
@@ -984,6 +997,9 @@ extension Common: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBas
     try { if let v = self._start {
       try visitor.visitSingularStringField(value: v, fieldNumber: 4)
     } }()
+    try { if let v = self._outputFilename {
+      try visitor.visitSingularStringField(value: v, fieldNumber: 5)
+    } }()
     try unknownFields.traverse(visitor: &visitor)
   }
 
@@ -992,6 +1008,7 @@ extension Common: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBas
     if lhs._description_p != rhs._description_p {return false}
     if lhs._operation != rhs._operation {return false}
     if lhs._start != rhs._start {return false}
+    if lhs._outputFilename != rhs._outputFilename {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }

--- a/ios/Encapp/utils/Statistics.swift
+++ b/ios/Encapp/utils/Statistics.swift
@@ -33,7 +33,11 @@ class Statistics {
         self.decodedFrames = Array<FrameInfo>()
         self.props = Array<JsonProperties>()
         date = Date();
-        id = "encapp_\(UUID().uuidString)"
+        if test.hasCommon && test.common.hasOutputFilename {
+            id = test.common.outputFilename
+        } else {
+            id = "encapp_\(UUID().uuidString)"
+        }
     }
 
     func start() {

--- a/proto/tests.proto
+++ b/proto/tests.proto
@@ -9,6 +9,12 @@ message Common {
   optional string description = 2;
   optional string operation = 3;
   optional string start = 4;
+  // template or specific name for output file(s)
+  // Placeholder markers are [] 
+  // e.g. [common.id].[input.resolution].[configuration.bitrate]-[XXXX]
+  // X is a substitution marker for A random hex number (1-f)
+  // If not set the filename will be encapp_uuid
+  optional string output_filename = 5;
 }
 
 enum DataValueType {

--- a/scripts/encapp_corpus_test.py
+++ b/scripts/encapp_corpus_test.py
@@ -226,7 +226,7 @@ def run_encapp(files, md5sums, options):
             clear_files(options)
     # Done with the encoding
     # Find all output json file (let us check the number as well).
-    json_files = glob.glob(f"{local_workdir}/encapp_*.json")
+    json_files = glob.glob(f"{local_workdir}/*.json")
     quality_options = {}
     quality_options["media_path"] = options.mediastore
     result = []
@@ -375,7 +375,6 @@ def filter_files_on_name(files, options):
 
 def filter_files(files, options):
     if options.resolution is None and options.framerate is None:
-        print("Filter none")
         return files
 
     for folder in options.corpus_dir:

--- a/scripts/proto/tests_pb2.py
+++ b/scripts/proto/tests_pb2.py
@@ -13,7 +13,7 @@ _sym_db = _symbol_database.Default()
 
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x0btests.proto\"K\n\x06\x43ommon\x12\n\n\x02id\x18\x01 \x01(\t\x12\x13\n\x0b\x64\x65scription\x18\x02 \x01(\t\x12\x11\n\toperation\x18\x03 \x01(\t\x12\r\n\x05start\x18\x04 \x01(\t\"W\n\tParameter\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\x1c\n\x04type\x18\x02 \x01(\x0e\x32\x0e.DataValueType\x12\r\n\x05value\x18\x03 \x01(\t\x12\x10\n\x08\x66ramenum\x18\x04 \x01(\x03\"\xb9\x01\n\x05Input\x12\x10\n\x08\x66ilepath\x18\x01 \x01(\t\x12\x12\n\nresolution\x18\x02 \x01(\t\x12\x18\n\x07pix_fmt\x18\x03 \x01(\x0e\x32\x07.PixFmt\x12\x11\n\tframerate\x18\x04 \x01(\x02\x12\x16\n\x0eplayout_frames\x18\x05 \x01(\x05\x12\x0f\n\x07pursuit\x18\x06 \x01(\x05\x12\x10\n\x08realtime\x18\x07 \x01(\x08\x12\x14\n\x0cstoptime_sec\x18\x08 \x01(\x02\x12\x0c\n\x04show\x18\t \x01(\x08\"\xcc\x06\n\tConfigure\x12\x1d\n\tparameter\x18\x01 \x03(\x0b\x32\n.Parameter\x12\r\n\x05\x63odec\x18\x02 \x01(\t\x12\x0e\n\x06\x65ncode\x18\x03 \x01(\x08\x12\x0f\n\x07surface\x18\x04 \x01(\x08\x12\x0c\n\x04mime\x18\x05 \x01(\t\x12\x0f\n\x07\x62itrate\x18\x06 \x01(\t\x12,\n\x0c\x62itrate_mode\x18\x07 \x01(\x0e\x32\x16.Configure.BitrateMode\x12\x12\n\ndurationUs\x18\x08 \x01(\x04\x12\x12\n\nresolution\x18\t \x01(\t\x12\x14\n\x0c\x63olor_format\x18\n \x01(\x05\x12\x30\n\x0e\x63olor_standard\x18\x0b \x01(\x0e\x32\x18.Configure.ColorStandard\x12*\n\x0b\x63olor_range\x18\x0c \x01(\x0e\x32\x15.Configure.ColorRange\x12\x30\n\x0e\x63olor_transfer\x18\r \x01(\x0e\x32\x18.Configure.ColorTransfer\x12\x1e\n\x16\x63olor_transfer_request\x18\x0e \x01(\t\x12\x11\n\tframerate\x18\x0f \x01(\x02\x12\x18\n\x10i_frame_interval\x18\x10 \x01(\x05\x12\x1c\n\x14intra_refresh_period\x18\x11 \x01(\x05\x12\x0f\n\x07latency\x18\x12 \x01(\x05\x12#\n\x1brepeat_previous_frame_after\x18\x13 \x01(\x03\x12\x11\n\tts_schema\x18\x14 \x01(\t\x12\x0f\n\x07quality\x18\x15 \x01(\x05\x12\x12\n\ncomplexity\x18\x16 \x01(\x05\x12\x1a\n\x0b\x64\x65\x63ode_dump\x18\x17 \x01(\x08:\x05\x66\x61lse\"3\n\x0b\x42itrateMode\x12\x06\n\x02\x63q\x10\x00\x12\x07\n\x03vbr\x10\x01\x12\x07\n\x03\x63\x62r\x10\x02\x12\n\n\x06\x63\x62r_fd\x10\x03\"E\n\rColorStandard\x12\r\n\tbt601_pal\x10\x02\x12\x0e\n\nbt601_ntsc\x10\x04\x12\t\n\x05\x62t709\x10\x01\x12\n\n\x06\x62t2020\x10\x06\"#\n\nColorRange\x12\x08\n\x04\x66ull\x10\x01\x12\x0b\n\x07limited\x10\x02\"?\n\rColorTransfer\x12\n\n\x06linear\x10\x01\x12\r\n\tsdr_video\x10\x03\x12\n\n\x06st2084\x10\x06\x12\x07\n\x03hlg\x10\x07\"\xc0\x02\n\x07Runtime\x12\x1d\n\tparameter\x18\x01 \x03(\x0b\x32\n.Parameter\x12\x35\n\rvideo_bitrate\x18\x02 \x03(\x0b\x32\x1e.Runtime.VideoBitrateParameter\x12\x0c\n\x04\x64rop\x18\x03 \x03(\x03\x12=\n\x11\x64ynamic_framerate\x18\x04 \x03(\x0b\x32\".Runtime.DynamicFramerateParameter\x12\x14\n\x0crequest_sync\x18\x05 \x03(\x03\x1a:\n\x15VideoBitrateParameter\x12\x10\n\x08\x66ramenum\x18\x01 \x01(\x03\x12\x0f\n\x07\x62itrate\x18\x02 \x01(\t\x1a@\n\x19\x44ynamicFramerateParameter\x12\x10\n\x08\x66ramenum\x18\x01 \x01(\x03\x12\x11\n\tframerate\x18\x02 \x01(\x02\"@\n\x10\x44\x65\x63oderConfigure\x12\x1d\n\tparameter\x18\x01 \x03(\x0b\x32\n.Parameter\x12\r\n\x05\x63odec\x18\x02 \x01(\t\"/\n\x0e\x44\x65\x63oderRuntime\x12\x1d\n\tparameter\x18\x01 \x03(\x0b\x32\n.Parameter\"\x1f\n\x08Parallel\x12\x13\n\x04test\x18\x01 \x03(\x0b\x32\x05.Test\"\x1d\n\x06Serial\x12\x13\n\x04test\x18\x01 \x03(\x0b\x32\x05.Test\"\xe5\x01\n\x04Test\x12\x17\n\x06\x63ommon\x18\x01 \x01(\x0b\x32\x07.Common\x12\x15\n\x05input\x18\x02 \x01(\x0b\x32\x06.Input\x12\x1d\n\tconfigure\x18\x03 \x01(\x0b\x32\n.Configure\x12\x19\n\x07runtime\x18\x04 \x01(\x0b\x32\x08.Runtime\x12,\n\x11\x64\x65\x63oder_configure\x18\x05 \x01(\x0b\x32\x11.DecoderConfigure\x12(\n\x0f\x64\x65\x63oder_runtime\x18\x06 \x01(\x0b\x32\x0f.DecoderRuntime\x12\x1b\n\x08parallel\x18\x07 \x01(\x0b\x32\t.Parallel\" \n\tTestSuite\x12\x13\n\x04test\x18\x01 \x03(\x0b\x32\x05.Test*I\n\rDataValueType\x12\x0e\n\nstringType\x10\x00\x12\x0b\n\x07intType\x10\x01\x12\r\n\tfloatType\x10\x02\x12\x0c\n\x08longType\x10\x03*L\n\x06PixFmt\x12\x0b\n\x07yuv420p\x10\x00\x12\x0b\n\x07yvu420p\x10\x01\x12\x08\n\x04nv12\x10\x02\x12\x08\n\x04nv21\x10\x03\x12\x08\n\x04rgba\x10\x04\x12\n\n\x06p010le\x10\x36\x42-\n\x19\x63om.facebook.encapp.protoB\x0eTestDefinitionP\x01')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x0btests.proto\"d\n\x06\x43ommon\x12\n\n\x02id\x18\x01 \x01(\t\x12\x13\n\x0b\x64\x65scription\x18\x02 \x01(\t\x12\x11\n\toperation\x18\x03 \x01(\t\x12\r\n\x05start\x18\x04 \x01(\t\x12\x17\n\x0foutput_filename\x18\x05 \x01(\t\"W\n\tParameter\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\x1c\n\x04type\x18\x02 \x01(\x0e\x32\x0e.DataValueType\x12\r\n\x05value\x18\x03 \x01(\t\x12\x10\n\x08\x66ramenum\x18\x04 \x01(\x03\"\xb9\x01\n\x05Input\x12\x10\n\x08\x66ilepath\x18\x01 \x01(\t\x12\x12\n\nresolution\x18\x02 \x01(\t\x12\x18\n\x07pix_fmt\x18\x03 \x01(\x0e\x32\x07.PixFmt\x12\x11\n\tframerate\x18\x04 \x01(\x02\x12\x16\n\x0eplayout_frames\x18\x05 \x01(\x05\x12\x0f\n\x07pursuit\x18\x06 \x01(\x05\x12\x10\n\x08realtime\x18\x07 \x01(\x08\x12\x14\n\x0cstoptime_sec\x18\x08 \x01(\x02\x12\x0c\n\x04show\x18\t \x01(\x08\"\xcc\x06\n\tConfigure\x12\x1d\n\tparameter\x18\x01 \x03(\x0b\x32\n.Parameter\x12\r\n\x05\x63odec\x18\x02 \x01(\t\x12\x0e\n\x06\x65ncode\x18\x03 \x01(\x08\x12\x0f\n\x07surface\x18\x04 \x01(\x08\x12\x0c\n\x04mime\x18\x05 \x01(\t\x12\x0f\n\x07\x62itrate\x18\x06 \x01(\t\x12,\n\x0c\x62itrate_mode\x18\x07 \x01(\x0e\x32\x16.Configure.BitrateMode\x12\x12\n\ndurationUs\x18\x08 \x01(\x04\x12\x12\n\nresolution\x18\t \x01(\t\x12\x14\n\x0c\x63olor_format\x18\n \x01(\x05\x12\x30\n\x0e\x63olor_standard\x18\x0b \x01(\x0e\x32\x18.Configure.ColorStandard\x12*\n\x0b\x63olor_range\x18\x0c \x01(\x0e\x32\x15.Configure.ColorRange\x12\x30\n\x0e\x63olor_transfer\x18\r \x01(\x0e\x32\x18.Configure.ColorTransfer\x12\x1e\n\x16\x63olor_transfer_request\x18\x0e \x01(\t\x12\x11\n\tframerate\x18\x0f \x01(\x02\x12\x18\n\x10i_frame_interval\x18\x10 \x01(\x05\x12\x1c\n\x14intra_refresh_period\x18\x11 \x01(\x05\x12\x0f\n\x07latency\x18\x12 \x01(\x05\x12#\n\x1brepeat_previous_frame_after\x18\x13 \x01(\x03\x12\x11\n\tts_schema\x18\x14 \x01(\t\x12\x0f\n\x07quality\x18\x15 \x01(\x05\x12\x12\n\ncomplexity\x18\x16 \x01(\x05\x12\x1a\n\x0b\x64\x65\x63ode_dump\x18\x17 \x01(\x08:\x05\x66\x61lse\"3\n\x0b\x42itrateMode\x12\x06\n\x02\x63q\x10\x00\x12\x07\n\x03vbr\x10\x01\x12\x07\n\x03\x63\x62r\x10\x02\x12\n\n\x06\x63\x62r_fd\x10\x03\"E\n\rColorStandard\x12\r\n\tbt601_pal\x10\x02\x12\x0e\n\nbt601_ntsc\x10\x04\x12\t\n\x05\x62t709\x10\x01\x12\n\n\x06\x62t2020\x10\x06\"#\n\nColorRange\x12\x08\n\x04\x66ull\x10\x01\x12\x0b\n\x07limited\x10\x02\"?\n\rColorTransfer\x12\n\n\x06linear\x10\x01\x12\r\n\tsdr_video\x10\x03\x12\n\n\x06st2084\x10\x06\x12\x07\n\x03hlg\x10\x07\"\xc0\x02\n\x07Runtime\x12\x1d\n\tparameter\x18\x01 \x03(\x0b\x32\n.Parameter\x12\x35\n\rvideo_bitrate\x18\x02 \x03(\x0b\x32\x1e.Runtime.VideoBitrateParameter\x12\x0c\n\x04\x64rop\x18\x03 \x03(\x03\x12=\n\x11\x64ynamic_framerate\x18\x04 \x03(\x0b\x32\".Runtime.DynamicFramerateParameter\x12\x14\n\x0crequest_sync\x18\x05 \x03(\x03\x1a:\n\x15VideoBitrateParameter\x12\x10\n\x08\x66ramenum\x18\x01 \x01(\x03\x12\x0f\n\x07\x62itrate\x18\x02 \x01(\t\x1a@\n\x19\x44ynamicFramerateParameter\x12\x10\n\x08\x66ramenum\x18\x01 \x01(\x03\x12\x11\n\tframerate\x18\x02 \x01(\x02\"@\n\x10\x44\x65\x63oderConfigure\x12\x1d\n\tparameter\x18\x01 \x03(\x0b\x32\n.Parameter\x12\r\n\x05\x63odec\x18\x02 \x01(\t\"/\n\x0e\x44\x65\x63oderRuntime\x12\x1d\n\tparameter\x18\x01 \x03(\x0b\x32\n.Parameter\"\x1f\n\x08Parallel\x12\x13\n\x04test\x18\x01 \x03(\x0b\x32\x05.Test\"\x1d\n\x06Serial\x12\x13\n\x04test\x18\x01 \x03(\x0b\x32\x05.Test\"\xe5\x01\n\x04Test\x12\x17\n\x06\x63ommon\x18\x01 \x01(\x0b\x32\x07.Common\x12\x15\n\x05input\x18\x02 \x01(\x0b\x32\x06.Input\x12\x1d\n\tconfigure\x18\x03 \x01(\x0b\x32\n.Configure\x12\x19\n\x07runtime\x18\x04 \x01(\x0b\x32\x08.Runtime\x12,\n\x11\x64\x65\x63oder_configure\x18\x05 \x01(\x0b\x32\x11.DecoderConfigure\x12(\n\x0f\x64\x65\x63oder_runtime\x18\x06 \x01(\x0b\x32\x0f.DecoderRuntime\x12\x1b\n\x08parallel\x18\x07 \x01(\x0b\x32\t.Parallel\" \n\tTestSuite\x12\x13\n\x04test\x18\x01 \x03(\x0b\x32\x05.Test*I\n\rDataValueType\x12\x0e\n\nstringType\x10\x00\x12\x0b\n\x07intType\x10\x01\x12\r\n\tfloatType\x10\x02\x12\x0c\n\x08longType\x10\x03*L\n\x06PixFmt\x12\x0b\n\x07yuv420p\x10\x00\x12\x0b\n\x07yvu420p\x10\x01\x12\x08\n\x04nv12\x10\x02\x12\x08\n\x04nv21\x10\x03\x12\x08\n\x04rgba\x10\x04\x12\n\n\x06p010le\x10\x36\x42-\n\x19\x63om.facebook.encapp.protoB\x0eTestDefinitionP\x01')
 
 _globals = globals()
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, _globals)
@@ -21,42 +21,42 @@ _builder.BuildTopDescriptorsAndMessages(DESCRIPTOR, 'tests_pb2', _globals)
 if _descriptor._USE_C_DESCRIPTORS == False:
   DESCRIPTOR._options = None
   DESCRIPTOR._serialized_options = b'\n\031com.facebook.encapp.protoB\016TestDefinitionP\001'
-  _globals['_DATAVALUETYPE']._serialized_start=1984
-  _globals['_DATAVALUETYPE']._serialized_end=2057
-  _globals['_PIXFMT']._serialized_start=2059
-  _globals['_PIXFMT']._serialized_end=2135
+  _globals['_DATAVALUETYPE']._serialized_start=2009
+  _globals['_DATAVALUETYPE']._serialized_end=2082
+  _globals['_PIXFMT']._serialized_start=2084
+  _globals['_PIXFMT']._serialized_end=2160
   _globals['_COMMON']._serialized_start=15
-  _globals['_COMMON']._serialized_end=90
-  _globals['_PARAMETER']._serialized_start=92
-  _globals['_PARAMETER']._serialized_end=179
-  _globals['_INPUT']._serialized_start=182
-  _globals['_INPUT']._serialized_end=367
-  _globals['_CONFIGURE']._serialized_start=370
-  _globals['_CONFIGURE']._serialized_end=1214
-  _globals['_CONFIGURE_BITRATEMODE']._serialized_start=990
-  _globals['_CONFIGURE_BITRATEMODE']._serialized_end=1041
-  _globals['_CONFIGURE_COLORSTANDARD']._serialized_start=1043
-  _globals['_CONFIGURE_COLORSTANDARD']._serialized_end=1112
-  _globals['_CONFIGURE_COLORRANGE']._serialized_start=1114
-  _globals['_CONFIGURE_COLORRANGE']._serialized_end=1149
-  _globals['_CONFIGURE_COLORTRANSFER']._serialized_start=1151
-  _globals['_CONFIGURE_COLORTRANSFER']._serialized_end=1214
-  _globals['_RUNTIME']._serialized_start=1217
-  _globals['_RUNTIME']._serialized_end=1537
-  _globals['_RUNTIME_VIDEOBITRATEPARAMETER']._serialized_start=1413
-  _globals['_RUNTIME_VIDEOBITRATEPARAMETER']._serialized_end=1471
-  _globals['_RUNTIME_DYNAMICFRAMERATEPARAMETER']._serialized_start=1473
-  _globals['_RUNTIME_DYNAMICFRAMERATEPARAMETER']._serialized_end=1537
-  _globals['_DECODERCONFIGURE']._serialized_start=1539
-  _globals['_DECODERCONFIGURE']._serialized_end=1603
-  _globals['_DECODERRUNTIME']._serialized_start=1605
-  _globals['_DECODERRUNTIME']._serialized_end=1652
-  _globals['_PARALLEL']._serialized_start=1654
-  _globals['_PARALLEL']._serialized_end=1685
-  _globals['_SERIAL']._serialized_start=1687
-  _globals['_SERIAL']._serialized_end=1716
-  _globals['_TEST']._serialized_start=1719
-  _globals['_TEST']._serialized_end=1948
-  _globals['_TESTSUITE']._serialized_start=1950
-  _globals['_TESTSUITE']._serialized_end=1982
+  _globals['_COMMON']._serialized_end=115
+  _globals['_PARAMETER']._serialized_start=117
+  _globals['_PARAMETER']._serialized_end=204
+  _globals['_INPUT']._serialized_start=207
+  _globals['_INPUT']._serialized_end=392
+  _globals['_CONFIGURE']._serialized_start=395
+  _globals['_CONFIGURE']._serialized_end=1239
+  _globals['_CONFIGURE_BITRATEMODE']._serialized_start=1015
+  _globals['_CONFIGURE_BITRATEMODE']._serialized_end=1066
+  _globals['_CONFIGURE_COLORSTANDARD']._serialized_start=1068
+  _globals['_CONFIGURE_COLORSTANDARD']._serialized_end=1137
+  _globals['_CONFIGURE_COLORRANGE']._serialized_start=1139
+  _globals['_CONFIGURE_COLORRANGE']._serialized_end=1174
+  _globals['_CONFIGURE_COLORTRANSFER']._serialized_start=1176
+  _globals['_CONFIGURE_COLORTRANSFER']._serialized_end=1239
+  _globals['_RUNTIME']._serialized_start=1242
+  _globals['_RUNTIME']._serialized_end=1562
+  _globals['_RUNTIME_VIDEOBITRATEPARAMETER']._serialized_start=1438
+  _globals['_RUNTIME_VIDEOBITRATEPARAMETER']._serialized_end=1496
+  _globals['_RUNTIME_DYNAMICFRAMERATEPARAMETER']._serialized_start=1498
+  _globals['_RUNTIME_DYNAMICFRAMERATEPARAMETER']._serialized_end=1562
+  _globals['_DECODERCONFIGURE']._serialized_start=1564
+  _globals['_DECODERCONFIGURE']._serialized_end=1628
+  _globals['_DECODERRUNTIME']._serialized_start=1630
+  _globals['_DECODERRUNTIME']._serialized_end=1677
+  _globals['_PARALLEL']._serialized_start=1679
+  _globals['_PARALLEL']._serialized_end=1710
+  _globals['_SERIAL']._serialized_start=1712
+  _globals['_SERIAL']._serialized_end=1741
+  _globals['_TEST']._serialized_start=1744
+  _globals['_TEST']._serialized_end=1973
+  _globals['_TESTSUITE']._serialized_start=1975
+  _globals['_TESTSUITE']._serialized_end=2007
 # @@protoc_insertion_point(module_scope)


### PR DESCRIPTION
Added common.output_filename
Placeholder markers are []
e.g. [common.id].[input.resolution].[configuration.bitrate]-[XXXX] X is a substitution marker for A random hex number (1-f) If not set the filename will be encapp_uuid