### PR TITLE
upgrade protobuf compiler to 3.18 

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -51,7 +51,7 @@ dependencies {
 
 protobuf {
     protoc {
-        artifact = 'com.google.protobuf:protoc:3.11.0'
+        artifact = 'com.google.protobuf:protoc:3.18.0'
     }
     generateProtoTasks {
         all().each { task ->


### PR DESCRIPTION
which is minimum version with macOS aarch64 builds