### PR TITLE
several fixes for encapp_verify

### DIFF
--- a/scripts/encapp.py
+++ b/scripts/encapp.py
@@ -1549,6 +1549,7 @@ def add_args(parser):
     # replacement shortcuts
     parser.add_argument(
         "-i",
+        "--videofile",
         type=str,
         dest="videofile",
         default=default_values["videofile"],


### PR DESCRIPTION
`make verify` fails. I've been chasing up several issues. It seems that `encapp_verify` has some coupling on option handling from `encapp` but the two have diverged. Instead reuse the options from encapp and add the verify specific ones. 

Also make several fixes where function signatures appear to have diverged from the way they are being called. Tests are mostly running after this although `encapp_verify/bitrate_transcoder_show_aggr.pbtxt` seems to be either taking a very long time or is stuck, the Android side never returns.

At least one other test is failing  when running on latest Pixel 9

```
error: test id: "bitrate_surface" run_id: XXXXX result: error error_code: "Error: yuv->rgba conversion on surface encoder only supports nv21 (got yuv420p)"
```