### PR TITLE
encapp: Surface transcoder input side throttle

### DIFF
--- a/app/src/main/java/com/facebook/encapp/SurfaceTranscoder.java
+++ b/app/src/main/java/com/facebook/encapp/SurfaceTranscoder.java
@@ -509,8 +509,10 @@ public class SurfaceTranscoder extends SurfaceEncoder {
                             mDone = true;
                         }
                     }
-                    //Log.d(TAG, "Set lastpts = " + ptsUsec/1000 +" ms" + ", ptsOffset = " + mPtsOffset);
                     mLastPtsUs = ptsUsec;
+		    if (mRealtime) {
+			sleepUntilNextFrame();
+		    }
                 }
             }
         }


### PR DESCRIPTION
For realtime the input needs to be throttled. With setting "show" it would be realtime anyways (because of the sceduled draws) but the performance and latency would be different with more buffering. Now the transcoder will simlulate a realtime input system