### PR TITLE
feat: LCEVC integration 

### DIFF
--- a/README.lcevc.md
+++ b/README.lcevc.md
@@ -1,0 +1,121 @@
+LCEVC-Integrated encapp Build and Run Instructions
+--------------------------------
+
+1. Install V-Nova’s LCEVC SDK
+
+Get the following SDK packages from [V-Nova's download portal](https://download.v-nova.com) (sign-up required):
+- LCEVC Encoder SDK (Android)
+- Android x264 base plugin
+- Android MediaCodec base plugin
+
+Extract them into your local Maven repository:
+- Linux/Mac: `${HOME}/.m2/repository`
+- Windows: `C:\Users\<username>\.m2\repository`
+
+Ensure the structure is preserved:
+```
+com/vnova/lcevc/eil/
+com/vnova/lcevc/eilp/
+com/vnova/lcevc/jni/
+```
+
+Note: Verify that versions in your `~/.m2` match those in `app/build.gradle`. If not, update them accordingly.
+
+2. Setup and Build:
+
+The instructions for setting up your system environment and building x264 are at [x264 Build README](lcevc/x264/README.md)
+
+3. Build and Install encapp:
+
+```
+./scripts/encapp.py install
+adb shell appops set --uid com.facebook.encapp MANAGE_EXTERNAL_STORAGE allow
+```
+
+4. Configure the Test Script:
+
+In the test files (`.pbtxt`), parameters _codec_, _frameRate_, _i_frame_interval_ and _bitrate_ should be set in `test.configure`.
+
+Currently, only the `lcevc_h264` codec is supported. The supported base encoders are `mediacodec_h264` and `x264`.
+LCEVC EIL parameters can be passed in 2 ways.
+
+- As _direct parameters_ using the `parameter` object:
+```
+test {
+    common {
+        id: "X"
+        description: "Test description"
+    }
+    input {
+        filepath: "mediaX.yuv"
+        resolution: "WxH"
+    }
+    
+    configure {
+        codec: "lcevc_h264"
+        bitrate: "XXX kbps"
+        framerate: XX
+    }
+    parameter {
+        key: "base_encoder"
+        type: stringType
+        value: "x264" 
+    }
+    parameter {
+        key: "encoding_debug_residuals"
+        type: stringType
+        value: "true" 
+    }
+    parameter {
+        key: "qp_max"
+        type: intType
+        value: 40 
+    }
+}
+```
+
+- Using a _json config_ file passed to the `eil_params_path` parameter key:
+```
+test {
+    common {
+        id: "X"
+        description: "Test description"
+    }
+    input {
+        filepath: "mediaX.yuv"
+        resolution: "WxH"
+    }
+    
+    configure {
+        codec: "lcevc_h264"
+        bitrate: "XXX kbps"
+        framerate: XX
+    }
+    parameter {
+         key: "eil_params_path"
+         type: stringType
+         value: "/tmp/eilConfig.json" 
+    }
+}
+```
+
+NOTE: If both _json config_ and _direct parameter_ methods are used, only _direct parameter_ will be used.
+
+5. Run Test:
+
+The `lcevc` flag must be used when running lcevc encodes.
+```
+./scripts/encapp.py run tests/lcevc_x264.pbtxt --lcevc
+```
+
+6. Verify Test:
+
+FFmpeg and LCEVC Decoder SDK are required to run `encapp_quality.py`.
+The LCEVCDec binaries can also be found at [V-Nova's download portal](https://download.v-nova.com) under _LCEVC Decoder SDK (Android)_.
+
+```
+./scripts/encapp_quality.py --header --media /path/to/media/folder /path/to/json/file/in/media/folder --keep-quality-files --csv
+```
+This calculates the video quality properties (vmaf, ssim and psnr).
+- `--csv` writes the calculated qualities to a csv file.
+- `--keep-quality-files` stores the generated video quality files.

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -11,7 +11,20 @@ android {
         versionCode 1
         versionName "1.23"
         setProperty("archivesBaseName", applicationId + "-v" + versionName)
+
+        ndk {
+            abiFilters "arm64-v8a"
+        }
     }
+
+    packagingOptions {
+        pickFirst 'lib/x86/libc++_shared.so'
+        pickFirst 'lib/x86_64/libc++_shared.so'
+        pickFirst 'lib/armeabi-v7a/libc++_shared.so'
+        pickFirst 'lib/arm64-v8a/libc++_shared.so'
+        pickFirst 'META-INF/Notice.txt'
+    }
+
     buildTypes {
         release {
             minifyEnabled false
@@ -30,6 +43,8 @@ android {
             proto {
                 srcDir '../proto/'
             }
+
+            jniLibs.srcDirs = ['src/main/jniLibs', '../lcevc/x264/libs']
         }
     }
 
@@ -38,6 +53,45 @@ android {
         targetCompatibility JavaVersion.VERSION_1_8
     }
     ndkVersion '21.3.6528147'
+
+    flavorDimensions = ['layout']
+
+    productFlavors {
+        aosp {
+            dimension 'layout'
+        }
+
+        full {
+            dimension 'layout'
+        }
+
+        fullNoBenchmark {
+            dimension 'layout'
+        }
+
+        demo {
+            dimension 'layout'
+        }
+
+        nonconan {
+            dimension 'layout'
+        }
+    }
+}
+
+configurations {
+    javacpp
+}
+
+task javacppExtract(type: Copy) {
+    dependsOn configurations.javacpp
+
+    from { configurations.javacpp.collect { zipTree(it) } }
+    include "lib/**"
+    into "$buildDir/javacpp/"
+    android.sourceSets.main.jniLibs.srcDirs += ["$buildDir/javacpp/lib/"]
+
+    tasks.getByName('preBuild').dependsOn javacppExtract
 }
 
 dependencies {
@@ -46,8 +100,16 @@ dependencies {
     implementation group: 'com.google.protobuf', name: 'protobuf-java', version: '3.12.0'
     implementation group: 'com.google.protobuf', name: 'protobuf-java-util', version: '3.12.0'
     implementation 'com.google.code.gson:gson:2.8.0'
-}
 
+    implementation 'com.vnova.lcevc:eil:3.13.2'
+    implementation 'com.vnova.lcevc.eilp:mediacodec:3.13.2'
+    implementation 'com.vnova.lcevc.eilp:x264:3.13.2'
+    implementation 'com.vnova.lcevc:jni:3.13.2'
+    implementation 'com.vnova.lcevc:util:3.13.2'
+
+    implementation group: 'org.bytedeco', name: 'javacv', version: '1.5.11'
+    javacpp group: 'org.bytedeco', name: 'ffmpeg-platform', version: '7.1-1.5.11'
+}
 
 protobuf {
     protoc {

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -9,6 +9,7 @@
     <uses-feature android:name="android.hardware.camera" android:required="true" />
 
     <application
+        android:debuggable="true"
         android:requestLegacyExternalStorage="true"
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"

--- a/app/src/main/java/com/facebook/encapp/BufferTranscoder.java
+++ b/app/src/main/java/com/facebook/encapp/BufferTranscoder.java
@@ -236,34 +236,34 @@ public class BufferTranscoder extends Encoder  {
             mStats.setCodec(mCodec.getName());
         }
 
-    try {
-        MediaFormat mediaFormat = mDecoder.getOutputFormat();
-        Log.d(TAG, "Decoder output format");
-        logMediaFormat(mediaFormat);
-        mediaFormat = TestDefinitionHelper.mergeEncoderSettings(mTest, mediaFormat);
-        //TODO: color handling
-        // The decoder must output same colorformat as input. QC hw encoder does not take same pix fmt android sw decoder.
-        mediaFormat.setInteger(MediaFormat.KEY_COLOR_FORMAT, matchingColor);
-        mStats.pushTimestamp("encoder.configure");
-        mCodec.configure(
-                mediaFormat,
-                null /* surface */,
-                null /* crypto */,
-                MediaCodec.CONFIGURE_FLAG_ENCODE);
-        mStats.pushTimestamp("encoder.configure");
-        Log.d(TAG, "Check input format after encoder is configured");
-        logMediaFormat(mCodec.getInputFormat());
-
-        mMuxer = createMuxer(mCodec, mediaFormat);
         try {
-            Log.d(TAG, "Start encoder");
-            mStats.pushTimestamp("encoder.start");
-            mCodec.start();
-            mStats.pushTimestamp("encoder.start");
-        } catch (Exception ex) {
-            Log.e(TAG, "Start failed: " + ex.getMessage());
-            //return "Start encoding failed";
-        }
+            MediaFormat mediaFormat = mDecoder.getOutputFormat();
+            Log.d(TAG, "Decoder output format");
+            logMediaFormat(mediaFormat);
+            mediaFormat = TestDefinitionHelper.mergeEncoderSettings(mTest, mediaFormat);
+            //TODO: color handling
+            // The decoder must output same colorformat as input. QC hw encoder does not take same pix fmt android sw decoder.
+            mediaFormat.setInteger(MediaFormat.KEY_COLOR_FORMAT, matchingColor);
+            mStats.pushTimestamp("encoder.configure");
+            mCodec.configure(
+                    mediaFormat,
+                    null /* surface */,
+                    null /* crypto */,
+                    MediaCodec.CONFIGURE_FLAG_ENCODE);
+            mStats.pushTimestamp("encoder.configure");
+            Log.d(TAG, "Check input format after encoder is configured");
+            logMediaFormat(mCodec.getInputFormat());
+
+            mMuxer = createMuxer(mCodec, mediaFormat);
+            try {
+                Log.d(TAG, "Start encoder");
+                mStats.pushTimestamp("encoder.start");
+                mCodec.start();
+                mStats.pushTimestamp("encoder.start");
+            } catch (Exception ex) {
+                Log.e(TAG, "Start failed: " + ex.getMessage());
+                //return "Start encoding failed";
+            }
             // This is needed.
         } catch (MediaCodec.CodecException cex) {
             Log.e(TAG, "Configure failed: " + cex.getMessage());
@@ -405,9 +405,9 @@ public class BufferTranscoder extends Encoder  {
                 mDropNext |= dropFromDynamicFramerate(mInFramesCount);
                 updateDynamicFramerate(mInFramesCount);
                 //Check time, if to far off drop frame, minimize the drops so something is show.
-                long ptsUsec = mPts + (timestamp - (long) mFirstFrameTimestampUsec);
+                long presentationTimeUs = mPts + (timestamp - (long) mFirstFrameTimestampUsec);
 
-                if (mRealtime &&  mFirstFrameSystemTimeUsec > 0 && (diffUsec - ptsUsec) > mFrameTimeUsec * 2) {
+                if (mRealtime &&  mFirstFrameSystemTimeUsec > 0 && (diffUsec - presentationTimeUs) > mFrameTimeUsec * 2) {
                     if (mDropcount < mFrameRate) {
                         Log.d(TAG, mTest.getCommon().getId() + " - drop frame caused by slow decoder");
                         mDropNext = true;
@@ -421,7 +421,7 @@ public class BufferTranscoder extends Encoder  {
                     mDropNext = false;
                     codec.releaseOutputBuffer(index, false);
                 } else {
-                    mStats.startEncodingFrame(ptsUsec, mInFramesCount);
+                    mStats.startEncodingFrame(presentationTimeUs, mInFramesCount);
                     mFramesAdded++;
 
                     ByteBuffer outputBuf = mDecoder.getOutputBuffer(index);
@@ -479,15 +479,15 @@ public class BufferTranscoder extends Encoder  {
                     }
                     setDecoderRuntimeParameters(mTest, mInFramesCount);
                     // Source time is always what is read
-                    long ptsUsec = mExtractor.getSampleTime() + mPtsOffset;
+                    long presentationTimeUs = mExtractor.getSampleTime() + mPtsOffset;
                     if (mRealtime) {
                         // Limit the pace of incoming frames to the framerate
                         sleepUntilNextFrameSynched();
                     }
                     if (size > 0) {
-                        mStats.startDecodingFrame(ptsUsec, size, flags);
+                        mStats.startDecodingFrame(presentationTimeUs, size, flags);
                         try {
-                            mDecoder.queueInputBuffer(index, 0, size, ptsUsec, flags);
+                            mDecoder.queueInputBuffer(index, 0, size, presentationTimeUs, flags);
                         } catch (IllegalStateException ise) {
                             // Ignore this
                         }
@@ -502,11 +502,11 @@ public class BufferTranscoder extends Encoder  {
                     if (eof) {
                         mExtractor.seekTo(0, MediaExtractor.SEEK_TO_CLOSEST_SYNC);
                         mCurrentLoop++;
-                        if (ptsUsec > mLastPtsUs) {
-                            mPtsOffset = ptsUsec;
+                        if (presentationTimeUs > mLastPtsUs) {
+                            mPtsOffset = presentationTimeUs;
                         } else {
                             mPtsOffset = mLastPtsUs;
-                            ptsUsec = mPtsOffset;
+                            presentationTimeUs = mPtsOffset;
                         }
 
                         mLoopTime = mPtsOffset /1000000.0;
@@ -515,7 +515,7 @@ public class BufferTranscoder extends Encoder  {
                             mDone = true;
                         }
                     }
-                    mLastPtsUs = ptsUsec;
+                    mLastPtsUs = presentationTimeUs;
                 }
             }
         }

--- a/app/src/main/java/com/facebook/encapp/CustomEncoder.java
+++ b/app/src/main/java/com/facebook/encapp/CustomEncoder.java
@@ -3,8 +3,8 @@ package com.facebook.encapp;
 import static com.facebook.encapp.utils.TestDefinitionHelper.magnitudeToInt;
 
 import android.media.MediaCodec;
+import android.media.MediaCodecInfo;
 import android.media.MediaFormat;
-import android.os.Bundle;
 import android.util.Log;
 import android.util.Size;
 
@@ -17,7 +17,6 @@ import com.facebook.encapp.proto.Runtime;
 import com.facebook.encapp.proto.Test;
 import com.facebook.encapp.utils.FileReader;
 import com.facebook.encapp.utils.FrameInfo;
-import com.facebook.encapp.utils.MediaCodecInfoHelper;
 import com.facebook.encapp.utils.SizeUtils;
 import com.facebook.encapp.utils.Statistics;
 import com.facebook.encapp.utils.StringParameter;
@@ -42,14 +41,11 @@ import java.util.Vector;
 
 class CustomEncoder extends Encoder {
     protected static final String TAG = "encapp.buffer_x264_encoder";
-
     public static native int initEncoder(Parameter[] parameters, int width, int height, int colorFormat, int bitDepth);
     public static native byte[] getHeader();
     // TODO: can the size, color and bitdepth change runtime?
     public static native int encode(byte[] input, byte[] output, FrameInfo info);
-
     public static native StringParameter[] getAllEncoderSettings();
-
     public static native void updateSettings(Parameter[] parameters);
     public static native void close();
 
@@ -91,10 +87,6 @@ class CustomEncoder extends Encoder {
         }
     }
 
-    private long computePresentationTimeUs(int frameIndex) {
-        return frameIndex * 1000000 / 30;
-    }
-
     public static byte[] readYUVFromFile(String filePath, int size, int framePosition) throws IOException {
         byte[] inputBuffer = new byte[size];
         try (FileInputStream fis = new FileInputStream(filePath);
@@ -109,7 +101,6 @@ class CustomEncoder extends Encoder {
         return inputBuffer;
     }
 
-
     public static byte[][] extractSpsPps(byte[] headerArray) {
         int spsStart = -1;
         int spsEnd = -1;
@@ -122,9 +113,9 @@ class CustomEncoder extends Encoder {
                     (headerArray[i] == 0x00 && headerArray[i+1] == 0x00 && headerArray[i+2] == 0x01)) {
 
                 int nalType = headerArray[i + (headerArray[i + 2] == 0x01 ? 3 : 4)] & 0x1F;
-                if (nalType == 7 && spsStart == -1) { // SPS NAL unit type is 7
+                if (nalType == H264_NALU_TYPE_SPS && spsStart == -1) {
                     spsStart = i;
-                } else if (nalType == 8 && spsStart != -1 && spsEnd == -1) { // PPS NAL unit type is 8
+                } else if (nalType == H264_NALU_TYPE_PPS && spsStart != -1 && spsEnd == -1) {
                     spsEnd = i;
                     ppsStart = i;
                 }
@@ -143,25 +134,6 @@ class CustomEncoder extends Encoder {
         return new byte[][]{spsBuffer, ppsBuffer};
     }
 
-    public boolean checkIfKeyFrame(byte[] bitstream) {
-        int nalUnitType;
-        for (int i = 0; i < bitstream.length - 4; i++) {
-            // Check for the start code 0x00000001 or 0x000001
-            if ((bitstream[i] == 0x00 && bitstream[i+1] == 0x00 && bitstream[i+2] == 0x00 && bitstream[i+3] == 0x01) ||
-                    (bitstream[i] == 0x00 && bitstream[i+1] == 0x00 && bitstream[i+2] == 0x01)) {
-
-                nalUnitType = bitstream[i + (bitstream[i + 2] == 0x01 ? 3 : 4)] & 0x1F;
-
-                // Check if the NAL unit type is 5 (IDR frame)
-                if (nalUnitType == 5) {
-                    return true;
-                }
-            }
-        }
-        return false;
-    }
-
-
     public void setRuntimeParameters(int frame) {
         // go through all runtime settings and see which are due
         if (mRuntimeParams == null) return;
@@ -169,14 +141,14 @@ class CustomEncoder extends Encoder {
 
         for (Runtime.VideoBitrateParameter bitrate : mRuntimeParams.getVideoBitrateList()) {
             if (bitrate.getFramenum() == frame) {
-                params.add(Parameter.newBuilder().setKey("bitrate").setValue(String.valueOf(bitrate)).setType(DataValueType.stringType).build());
+                addEncoderParameters(params, DataValueType.intType.name(), BITRATE, String.valueOf(bitrate));
                 break;
             }
         }
 
         for (Long sync : mRuntimeParams.getRequestSyncList()) {
             if (sync == frame) {
-                params.add(Parameter.newBuilder().setKey("request-sync").setValue(String.valueOf("")).setType(DataValueType.stringType).build());
+                addEncoderParameters(params, DataValueType.longType.name(), "request-sync", "");
                 break;
             }
         }
@@ -213,24 +185,23 @@ class CustomEncoder extends Encoder {
 
         int width = sourceResolution.getWidth();
         int height = sourceResolution.getHeight();
-        int pixelformat = mTest.getInput().getPixFmt().getNumber();
-        int bitdepth = (pixelformat == PixFmt.p010le.getNumber())? 10: 8;
+        int pixelFormat = mTest.getInput().getPixFmt().getNumber();
+        int bitdepth = (pixelFormat == PixFmt.p010le.getNumber())? 10: 8;
         int bitrate = magnitudeToInt(mTest.getConfigure().getBitrate());
-        int bitratemode = mTest.getConfigure().getBitrateMode().getNumber();
-        int iframeinterval =  mTest.getConfigure().getIFrameInterval();
+        int bitrateMode = mTest.getConfigure().getBitrateMode().getNumber();
+        int iFrameInterval =  mTest.getConfigure().getIFrameInterval();
+        float framerate =  mTest.getConfigure().getFramerate();
 
         float crf = 23.0f;
-        Log.d(TAG, width + "x" + height + ",  pixelformat: " + pixelformat + ", bitdepth:" + bitdepth + ", bitrate_mode:" + bitratemode + ", bitrate: " + bitrate + ", iframeinterval: "+ iframeinterval);
-        // Create params for this
-
+        Log.d(TAG, width + "x" + height + ",  pixelFormat: " + pixelFormat + ", bitdepth:" + bitdepth + ", bitrate_mode:" + bitrateMode + ", bitrate: " + bitrate + ", iFrameInterval: "+ iFrameInterval);
 
         // Caching vital values and see if they can be set runtime.
         Vector<Parameter> params = new Vector(mTest.getConfigure().getParameterList());
         // This one needs to be set as a native param.
         try {
-            params.add(Parameter.newBuilder().setKey("bitrate").setValue(String.valueOf(bitrate)).setType(DataValueType.stringType).build());
-            params.add(Parameter.newBuilder().setKey("bitrate_mode").setValue(String.valueOf(bitratemode)).setType(DataValueType.stringType).build());
-            params.add(Parameter.newBuilder().setKey("i_frame_interval").setValue(String.valueOf(iframeinterval)).setType(DataValueType.stringType).build());
+            addEncoderParameters(params, DataValueType.intType.name(), BITRATE, String.valueOf(bitrate));
+            addEncoderParameters(params, DataValueType.intType.name(), BITRATE_MODE, String.valueOf(bitrateMode));
+            addEncoderParameters(params, DataValueType.floatType.name(), I_FRAME_INTERVAL, String.valueOf(iFrameInterval));
         } catch (Exception ex) {
             Log.d(TAG, "Exception: " + ex);
         }
@@ -276,7 +247,7 @@ class CustomEncoder extends Encoder {
 
             Parameter[] param_buffer = new Parameter[params.size()];
             params.toArray(param_buffer);
-            int status = initEncoder(param_buffer, width, height, pixelformat, bitdepth);
+            int status = initEncoder(param_buffer, width, height, pixelFormat, bitdepth);
             StringParameter[] settings_ = getAllEncoderSettings();
             //add generic parameters to mTest, this way it can bre exactly reproduced (?) - in the case x264: no
             ArrayList<Parameter> param_list = new ArrayList<>();
@@ -313,7 +284,7 @@ class CustomEncoder extends Encoder {
                             continue;
                         }
 
-                        long pts = computePresentationTimeUsec(mFramesAdded, mRefFrameTime);
+                        long pts = computePresentationTimeUs(mPts, mFramesAdded, mRefFrameTime);
                         info = mStats.startEncodingFrame(pts, mFramesAdded);
                         // Let us read the setting in native and force key frame if set here.
                         // If (for some reason a key frame is not produced it will be updated in the native code
@@ -345,16 +316,20 @@ class CustomEncoder extends Encoder {
                         format.setInteger(MediaFormat.KEY_WIDTH, width);
                         format.setInteger(MediaFormat.KEY_HEIGHT, height);
                         format.setInteger(MediaFormat.KEY_BIT_RATE, bitrate);
-                        format.setFloat(MediaFormat.KEY_FRAME_RATE, 30);//mFrameRate);
-                        format.setInteger(MediaFormat.KEY_COLOR_FORMAT, 20);//MediaCodecInfoHelper.mapEncappPixFmtToAndroidColorFormat(PixFmt.forNumber(pixelformat)));
-                        format.setInteger(MediaFormat.KEY_I_FRAME_INTERVAL, 3);//iframeinterval);//TODO:
+                        format.setFloat(MediaFormat.KEY_FRAME_RATE, framerate);
+                        format.setInteger(MediaFormat.KEY_COLOR_FORMAT, MediaCodecInfo.CodecCapabilities.COLOR_FormatYUV420PackedPlanar);
+                        format.setInteger(MediaFormat.KEY_I_FRAME_INTERVAL, iFrameInterval);
 
                         byte[][] spsPps = extractSpsPps(headerArray);
 
-                        ByteBuffer sps = ByteBuffer.wrap(spsPps[0]);
-                        ByteBuffer pps = ByteBuffer.wrap(spsPps[1]);
-                        format.setByteBuffer("csd-0", sps);
-                        format.setByteBuffer("csd-1", pps);
+                        try {
+                            ByteBuffer sps = ByteBuffer.wrap(spsPps[0]);
+                            ByteBuffer pps = ByteBuffer.wrap(spsPps[1]);
+                            format.setByteBuffer("csd-0", sps);
+                            format.setByteBuffer("csd-1", pps);
+                        } catch (Exception e) {
+                            Log.e(TAG, "Failed to extract the NAL SPS and PPS ", e);
+                        }
 
                         bufferInfo = new MediaCodec.BufferInfo();
                         videoTrackIndex = mMuxer.addTrack(format);
@@ -368,7 +343,7 @@ class CustomEncoder extends Encoder {
                     bufferInfo.presentationTimeUs = info.getPts();
 
                     //TODO: we get this from FrameInfo instead
-                    boolean isKeyFrame = checkIfKeyFrame(outputBuffer);
+                    boolean isKeyFrame = checkIfKeyFrame(outputBuffer, SyntaxType.H264);
                     if (isKeyFrame) bufferInfo.flags = MediaCodec.BUFFER_FLAG_KEY_FRAME;
 
                     if(mMuxer != null) {

--- a/app/src/main/java/com/facebook/encapp/Encoder.java
+++ b/app/src/main/java/com/facebook/encapp/Encoder.java
@@ -74,7 +74,23 @@ public abstract class Encoder {
     DataWriter mDataWriter;
     FpsMeasure mFpsMeasure;
     boolean mStable = true;
+    protected static int H264_NALU_TYPE_IDR = 5;
+    protected static int H264_NALU_TYPE_SPS = 7;
+    protected static int H264_NALU_TYPE_PPS = 8;
+    protected static int HEVC_NALU_TYPE_IDR = 16;
+    protected static int HEVC_NALU_TYPE_CRA = 21;
+    protected static int VVC_NALU_TYPE_IDR = 16;
+    protected static int VVC_NALU_TYPE_CRA = 23;
+    public static final String BITRATE = "bitrate";
+    public static final String BITRATE_MODE = "bitrate_mode";
+    public static final String I_FRAME_INTERVAL = "i_frame_interval";
+    public static final String FRAMERATE = "framerate";
 
+    public enum SyntaxType {
+        H264,
+        HEVC,
+        VVC
+    }
 
     public Encoder(Test test) {
         mTest = test;
@@ -107,6 +123,88 @@ public abstract class Encoder {
         }
         // prepend the workdir
         return CliSettings.getWorkDir() + "/" + path;
+    }
+
+    /**
+     * Finds the next start code or the end of the stream.
+     *
+     * @param param_list Vector of encoder parameters to configure Encapp's tests.
+     * @param parameterType The parameter type (int, string, float, long).
+     * @param parameterKey The parameter key.
+     * @param parameterValue The parameter value
+     */
+    public static void addEncoderParameters(Vector<Parameter> param_list, String parameterType, String parameterKey, String parameterValue) {
+        try {
+            DataValueType type = DataValueType.valueOf(parameterType);
+
+            switch (type) {
+                case intType:
+                    param_list.add(Parameter.newBuilder().setType(DataValueType.intType).setKey(parameterKey).setValue(parameterValue).build());
+                    break;
+                case longType:
+                    param_list.add(Parameter.newBuilder().setType(DataValueType.longType).setKey(parameterKey).setValue(parameterValue).build());
+                    break;
+                case floatType:
+                    param_list.add(Parameter.newBuilder().setType(DataValueType.floatType).setKey(parameterKey).setValue(parameterValue).build());
+                    break;
+                case stringType:
+                    param_list.add(Parameter.newBuilder().setType(DataValueType.stringType).setKey(parameterKey).setValue(parameterValue).build());
+                    break;
+                default:
+                    throw new IllegalArgumentException("Unknown encoder parameter type: " + parameterType);
+            }
+        } catch (IllegalArgumentException e) {
+            Log.e(TAG, "Error: " + e.getMessage());
+        }
+    }
+
+
+
+    /**
+     * Return true if the stream is a key frame
+     *
+     * @param bitstream Byte stream of encoded frames.
+     */
+    public static boolean checkIfKeyFrame(byte[] bitstream, SyntaxType syntaxType) {
+        for (int i = 0; i < bitstream.length - 4; i++) {
+            // Find start code (0x000001 or 0x00000001)
+            if ((bitstream[i] == 0x00 && bitstream[i + 1] == 0x00 &&
+                    bitstream[i + 2] == 0x01) ||
+                    (bitstream[i] == 0x00 && bitstream[i + 1] == 0x00 &&
+                            bitstream[i + 2] == 0x00 && bitstream[i + 3] == 0x01)) {
+
+                int nalHeaderIndex = i + (bitstream[i + 2] == 0x01 ? 3 : 4);
+                if (nalHeaderIndex >= bitstream.length) continue;
+
+                int nalHeader = bitstream[nalHeaderIndex] & 0xFF;
+
+                switch (syntaxType) {
+                    case H264: {
+                        int nalUnitType = nalHeader & 0x1F;
+                        if (nalUnitType == H264_NALU_TYPE_IDR) {
+                            return true;
+                        }
+                        break;
+                    }
+                    case HEVC: {
+                        int nalUnitType = (nalHeader >> 1) & 0x3F;
+                        if (nalUnitType >= HEVC_NALU_TYPE_IDR && nalUnitType <= HEVC_NALU_TYPE_CRA) {
+                            return true;
+                        }
+                        break;
+                    }
+                    case VVC: {
+                        if (nalHeaderIndex + 1 >= bitstream.length) break;
+                        int nalUnitType = (bitstream[nalHeaderIndex + 1] >> 3) & 0x1F;
+                        if (nalUnitType >= VVC_NALU_TYPE_IDR && nalUnitType <= VVC_NALU_TYPE_CRA) {
+                            return true;
+                        }
+                        break;
+                    }
+                }
+            }
+        }
+        return false;
     }
 
     protected void sleepUntilNextFrame(double frameTimeUsec) {
@@ -147,8 +245,8 @@ public abstract class Encoder {
     /**
      * Generates the presentation time for frameIndex, in microseconds.
      */
-    protected long computePresentationTimeUsec(int frameIndex, double frameTimeUsec) {
-        return mPts + (long) (frameIndex * frameTimeUsec);
+    public static long computePresentationTimeUs(long referencePts, int frameIndex, double frameTimeUs) {
+        return referencePts + (long) (frameIndex * frameTimeUs);
     }
 
     protected double calculateFrameTimingUsec(float frameRate) {
@@ -237,7 +335,7 @@ public abstract class Encoder {
         }
         // 4. stop the reader in non-loop mode:
         // stop when the file is empty
-       if ((!loop && fileReader != null) && fileReader.isClosed()) {
+        if ((!loop && fileReader != null) && fileReader.isClosed()) {
             return true;
         }
         // do not stop the reader
@@ -342,8 +440,8 @@ public abstract class Encoder {
             byteBuffer.clear();
             read = fileReader.fillBuffer(byteBuffer, size);
         }
-        long ptsUsec = computePresentationTimeUsec(frameCount, mRefFrameTime);
-        mCurrentTimeSec =  ptsUsec / 1000000.0f;
+        long presentationTimeUs = computePresentationTimeUs(mPts, frameCount, mRefFrameTime);
+        mCurrentTimeSec =  presentationTimeUs / 1000000.0f;
         // set any runtime parameters for this frame
         setRuntimeParameters(mInFramesCount);
         // support for dropping frames
@@ -362,10 +460,10 @@ public abstract class Encoder {
             if (mRealtime) {
                 sleepUntilNextFrame();
             }
-            mStats.startEncodingFrame(ptsUsec, frameCount);
-            codec.queueInputBuffer(index, 0 /* offset */, read, ptsUsec /* timeUs */, flags);
+            mStats.startEncodingFrame(presentationTimeUs, frameCount);
+            codec.queueInputBuffer(index, 0 /* offset */, read, presentationTimeUs /* timeUs */, flags);
         } else if ((flags & MediaCodec.BUFFER_FLAG_END_OF_STREAM) != 0) {
-            codec.queueInputBuffer(index, 0 /* offset */, 0, ptsUsec /* timeUs */, MediaCodec.BUFFER_FLAG_END_OF_STREAM);
+            codec.queueInputBuffer(index, 0 /* offset */, 0, presentationTimeUs /* timeUs */, MediaCodec.BUFFER_FLAG_END_OF_STREAM);
         } else {
             read = -1;
         }
@@ -411,7 +509,7 @@ public abstract class Encoder {
                         }
                         mCodec.releaseOutputBuffer(frameBuffer.mBufferId, false /* render */);
                         if (currentOutputFormat == null) {
-                           currentOutputFormat =  mCodec.getOutputFormat();
+                            currentOutputFormat =  mCodec.getOutputFormat();
                         }
                     } else {
                         if ((frameBuffer.mInfo.flags & MediaCodec.BUFFER_FLAG_END_OF_STREAM) != 0) {

--- a/app/src/main/java/com/facebook/encapp/LcevcEncoder.java
+++ b/app/src/main/java/com/facebook/encapp/LcevcEncoder.java
@@ -1,0 +1,1082 @@
+package com.facebook.encapp;
+
+import static com.facebook.encapp.utils.TestDefinitionHelper.magnitudeToInt;
+
+import android.media.MediaCodec;
+import android.media.MediaCodecInfo;
+import android.media.MediaFormat;
+import android.media.MediaMuxer;
+import android.util.Log;
+import android.util.Size;
+
+import androidx.annotation.NonNull;
+
+import com.facebook.encapp.proto.DataValueType;
+import com.facebook.encapp.proto.Parameter;
+import com.facebook.encapp.proto.PixFmt;
+import com.facebook.encapp.proto.Runtime;
+import com.facebook.encapp.proto.Test;
+import com.facebook.encapp.utils.CliSettings;
+import com.facebook.encapp.utils.FileReader;
+import com.facebook.encapp.utils.FrameInfo;
+import com.facebook.encapp.utils.SizeUtils;
+import com.facebook.encapp.utils.Statistics;
+import com.facebook.encapp.utils.TestDefinitionHelper;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
+import java.nio.file.Files;
+import java.util.Arrays;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Vector;
+import java.util.Iterator;
+
+import java.io.Closeable;
+import java.nio.file.Paths;
+import java.nio.file.StandardOpenOption;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.Locale;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import com.vnova.lcevc.jni.EIL;
+import com.vnova.lcevc.eil.AndroidEIL;
+
+import org.bytedeco.ffmpeg.avcodec.AVCodec;
+import org.bytedeco.ffmpeg.avcodec.AVCodecContext;
+import org.bytedeco.ffmpeg.avcodec.AVPacket;
+import org.bytedeco.ffmpeg.avformat.AVIOContext;
+import org.bytedeco.ffmpeg.avformat.AVStream;
+import org.bytedeco.ffmpeg.avformat.AVFormatContext;
+import org.bytedeco.ffmpeg.avformat.AVOutputFormat;
+import static org.bytedeco.ffmpeg.global.avcodec.*;
+import static org.bytedeco.ffmpeg.global.avformat.*;
+import static org.bytedeco.ffmpeg.global.avutil.*;
+import org.bytedeco.javacpp.BytePointer;
+import org.bytedeco.javacpp.PointerPointer;
+
+
+class LcevcEncoder extends Encoder {
+    protected static final String TAG = "LCEVC Encoder";
+    public LcevcEncoder(Test test) {
+        super(test);
+        mStats = new Statistics("lcevc_encoder", mTest);
+    }
+
+    public void setRuntimeParameters(int frame) {
+        // go through all runtime settings and see which are due
+        if (mRuntimeParams == null)
+            return;
+        Vector<Parameter> params = new Vector();
+
+        for (Runtime.VideoBitrateParameter bitrate : mRuntimeParams.getVideoBitrateList()) {
+            if (bitrate.getFramenum() == frame) {
+                addEncoderParameters(params, DataValueType.intType.name(), BITRATE, String.valueOf(bitrate));
+                break;
+            }
+        }
+
+        for (Long sync : mRuntimeParams.getRequestSyncList()) {
+            if (sync == frame) {
+                addEncoderParameters(params, DataValueType.longType.name(), "request-sync", "");
+                break;
+            }
+        }
+
+        for (Parameter param : mRuntimeParams.getParameterList()) {
+            if (param.getFramenum() == frame) {
+                Log.d(TAG, "Set runtime parameter @ " + frame + " key: " + param.getKey() + ", " + param.getType()
+                        + ", " + param.getValue());
+            }
+        }
+
+        Parameter[] param_buffer = new Parameter[params.size()];
+        params.toArray(param_buffer);
+    }
+
+    /**
+     Get all lcevc-based encoder settings from the tests' proto files.
+     These are the json keys with "parameter".
+     */
+    public void getBaseEncoderConfig(Vector<Parameter> encoder_base_config) {
+        try {
+            int bitrate = magnitudeToInt(mTest.getConfigure().getBitrate());
+            int iFrameInterval = mTest.getConfigure().getIFrameInterval();
+            float frameRate = mTest.getConfigure().getFramerate();
+
+            addEncoderParameters(encoder_base_config, DataValueType.intType.name(), BITRATE, String.valueOf(bitrate));
+            addEncoderParameters(encoder_base_config, DataValueType.intType.name(), I_FRAME_INTERVAL, String.valueOf(iFrameInterval));
+            addEncoderParameters(encoder_base_config, DataValueType.floatType.name(), FRAMERATE, String.valueOf(frameRate));
+
+        } catch (Exception ex) {
+            Log.d(TAG, "Exception: " + ex);
+        }
+    }
+
+    public String start() {
+        Log.d(TAG, "** LCEVC encoding - " + mTest.getCommon().getDescription() + " **");
+        mTest = TestDefinitionHelper.updateBasicSettings(mTest);
+        if (mTest.hasRuntime())
+            mRuntimeParams = mTest.getRuntime();
+        if (mTest.getInput().hasRealtime())
+            mRealtime = mTest.getInput().getRealtime();
+
+        mFrameRate = mTest.getConfigure().getFramerate();
+        mWriteFile = !mTest.getConfigure().hasEncode() || mTest.getConfigure().getEncode();
+        mSkipped = 0;
+        mFramesAdded = 0;
+        Size sourceResolution = SizeUtils.parseXString(mTest.getInput().getResolution());
+        mRefFramesizeInBytes = (int) (sourceResolution.getWidth() * sourceResolution.getHeight() * 1.5);
+        mYuvReader = new FileReader();
+
+        int width = sourceResolution.getWidth();
+        int height = sourceResolution.getHeight();
+        int pixelFormat = mTest.getInput().getPixFmt().getNumber();
+        int bitdepth = (pixelFormat == PixFmt.p010le.getNumber()) ? 10 : 8;
+        int bitrate = magnitudeToInt(mTest.getConfigure().getBitrate());
+        int bitrateMode = mTest.getConfigure().getBitrateMode().getNumber();
+        int iFrameInterval = mTest.getConfigure().getIFrameInterval();
+
+        Log.d(TAG, width + "x" + height + ",  pixelFormat: " + pixelFormat + ", bitdepth:" + bitdepth
+                + ", bitrate_mode:" + bitrateMode + ", bitrate: " + bitrate + ", iFrameInterval: " + iFrameInterval);
+
+        // Caching vital values and see if they can be set runtime.
+        Vector<Parameter> params = new Vector(mTest.getConfigure().getParameterList());
+        // This one needs to be set as a native param.
+        try {
+            addEncoderParameters(params, DataValueType.intType.name(), BITRATE, String.valueOf(bitrate));
+        } catch (Exception ex) {
+            Log.d(TAG, "Exception: " + ex);
+        }
+        if (!mYuvReader.openFile(checkFilePath(mTest.getInput().getFilepath()), mTest.getInput().getPixFmt())) {
+            return "Could not open file";
+        }
+
+        MediaFormat mediaFormat;
+        mediaFormat = TestDefinitionHelper.buildMediaFormat(mTest);
+        logMediaFormat(mediaFormat);
+        setConfigureParams(mTest, mediaFormat);
+
+        mStats.setEncoderMediaFormat(mediaFormat);
+
+        float mReferenceFrameRate = mTest.getInput().getFramerate();
+        mKeepInterval = mReferenceFrameRate / mFrameRate;
+        mRefFrameTime = calculateFrameTimingUsec(mReferenceFrameRate);
+
+        synchronized (this) {
+            Log.d(TAG, "Wait for synchronized start");
+            try {
+                mInitDone = true;
+                wait(WAIT_TIME_MS);
+            } catch (InterruptedException e) {
+                e.printStackTrace();
+            }
+        }
+        mStats.start();
+
+        try {
+            Vector<Parameter> encoder_eil_config = new Vector<>(mTest.getConfigure().getParameterList());
+
+            Vector<Parameter> encoder_base_config = new Vector<>();
+            getBaseEncoderConfig(encoder_base_config);
+
+            mTest = mTest.toBuilder().setConfigure(mTest.getConfigure().toBuilder().addAllParameter(encoder_base_config))
+                    .build();
+
+            Log.d(TAG, "Updated test: " + mTest);
+            mStats.updateTest(mTest);
+
+            // Initialise and run the LCEVC Encoder.
+            File inputFile;
+            EncoderEIL eilEncoder;
+
+            try {
+                inputFile = new File(mTest.getInput().getFilepath());
+            } catch (Exception ex) {
+                return "Unable to find suitable input file";
+            }
+
+            try {
+                eilEncoder = new EncoderEIL(
+                        inputFile,
+                        width,
+                        height,
+                        pixelFormat,
+                        encoder_base_config,
+                        encoder_eil_config,
+                        mStats,
+                        mPts,
+                        mRefFrameTime);
+            } catch (Exception ex) {
+                return "Unable to to open file";
+            }
+
+            boolean result = eilEncoder.run();
+            if (!result) {
+                return "Unable to access encode input file";
+            }
+
+            File encodedStreamFile = eilEncoder.getElementaryStream();
+            if (encodedStreamFile != null && !encodedStreamFile.exists()) {
+                return "Unable to access the LCEVC encoded stream file";
+            }
+
+            mStats.stop();
+
+            Log.d(TAG, "Close encoder and streams");
+
+        } catch (Exception ex) {
+            return ex.getMessage();
+        }
+
+        mYuvReader.closeFile();
+
+        return "";
+    }
+
+    public void writeToBuffer(@NonNull MediaCodec codec, int index, boolean encoder) {
+        // Not needed
+    }
+
+    public void readFromBuffer(@NonNull MediaCodec codec, int index, boolean encoder, MediaCodec.BufferInfo info) {
+        // Not needed
+    }
+
+    public void stopAllActivity() {
+        // Not needed
+    }
+
+    public void release() {
+        // Not needed
+    }
+}
+
+/**
+ * EIL Class that implements the LCEVC encoding and muxing.
+ */
+class EncoderEIL {
+    private static final String TAG = "Lcevc Encoder EIL";
+    public static final String CONFIG_KEY_JSON = "eil_params_path";
+    public static final String CONFIG_KEY_BASE_ENCODER = "base_encoder";
+    public static final String CONFIG_KEY_GOP_LENGTH = "gop_length";
+    public static final String CODEC_MEDIACODEC_H264 = "mediacodec_h264";
+    public static final String CODEC_X264 = "x264";
+    private Input mInput;
+    private FileChannel mOutput;
+    private AndroidEIL mEIL;
+    private File mOutputFile;
+    String mMuxedFile = "";
+    private boolean mIsEOS = false;
+    private Statistics mStats;
+    private long mReferencePts = 0;
+    private double mRefFrameTime = 0;
+    private int mReceivedOutputBuffer = 0;
+    private EncoderProperty mEncoderProperty;
+
+    private ArrayList<AVPacketProperty> avPacketProperty;
+
+    /**
+     Read the input file and extracts the frames to be encoded.
+     */
+    static class Input implements Closeable
+    {
+        private File mFile;
+        private FileChannel mChannel;
+        private int mFrameSize = 0;
+        private int mFramesRead = 0;
+        private int mNumFrames = 0;
+
+        public Input(File file, int frameWidth, int frameHeight) {
+            mFile = file;
+            try {
+                mChannel = FileChannel.open(mFile.toPath(), StandardOpenOption.READ);
+            } catch (IOException ex) {
+                throw new RuntimeException("Cannot open file channel", ex);
+            }
+
+            mFrameSize = frameWidth * frameHeight * 3 / 2;
+
+            if (mFrameSize > 0) {
+                mNumFrames = (int) (mFile.length() / mFrameSize);
+            } else {
+                throw new RuntimeException("Input must have non-zero frame size");
+            }
+        }
+
+        public void close() throws IOException {
+            mChannel.close();
+        }
+
+        public int getFramesRead() {
+            return mFramesRead;
+        }
+
+        // Check if all frames have been read.
+        public boolean isFinished() {
+            return mFramesRead >= mNumFrames;
+        }
+
+        // Reads a frame's worth of data from a file into a buffer
+        public ByteBuffer nextFrame() throws IOException {
+            ByteBuffer buffer = ByteBuffer.allocateDirect(mFrameSize);
+
+            if (mChannel.read(buffer) == mFrameSize) {
+                mFramesRead++;
+                return buffer;
+            }
+
+            return null;
+        }
+
+    }
+
+    /**
+     Handle associated libavformat av property for muxing.
+     */
+    static class AVPacketProperty {
+        private byte[] mPacket;
+        private int mPts;
+        private int mDts;
+        private int mSize;
+
+        public AVPacketProperty(ByteBuffer byteBuffer, int pts, int dts, int size) {
+            byteBuffer.flip();
+
+            mPacket= new byte[byteBuffer.remaining()];
+            byteBuffer.get(mPacket);
+
+            mSize = size;
+            mPts = pts;
+            mDts = dts;
+        }
+
+
+        public byte[] getPacket() {
+            return mPacket;
+        }
+
+        public int getPts() {
+            return mPts;
+        }
+
+        public int getDts() {
+            return mDts;
+        }
+
+        public int getSize() {
+            return mSize;
+        }
+    }
+
+    /**
+     Hold base and eil encoder parameters.
+     */
+    static class EncoderProperty {
+        int mFrameWidth = 0;
+        int mFrameHeight = 0;
+        int mBitrate = 0;
+        int mIframeinterval = 0;
+        float mFramerate = 0;
+        int mPixelFormat = 0;
+
+        HashMap<String, Object> mEILParameters;
+
+        EncoderProperty(int width, int height, int pixelFormat, Vector<Parameter> base_config, Vector<Parameter> eil_config) {
+            mFrameWidth = width;;
+            mFrameHeight = height;
+            mPixelFormat = pixelFormat;
+            mEILParameters = new HashMap<>();
+
+            // Extract the bitrate, frame rate and iframe interval from the base config.
+            for(int i=0; i<base_config.size(); i++) {
+                Parameter param = base_config.elementAt(i);
+                if (param.getKey().equals(Encoder.BITRATE) ) {
+                    mBitrate = Integer.parseInt(param.getValue());
+                }
+                else if (param.getKey().equals(Encoder.I_FRAME_INTERVAL)) {
+                    mIframeinterval = Integer.parseInt(param.getValue());
+                }
+                else if (param.getKey().equals(Encoder.FRAMERATE)) {
+                    mFramerate = Float.parseFloat(param.getValue());
+                }
+            }
+
+            // Extract the eil parameters and store in a key-value map.
+            for(int i=0; i<eil_config.size(); i++) {
+                Parameter param = eil_config.elementAt(i);
+                mEILParameters.put(param.getKey(), param.getValue());
+            }
+
+        }
+
+        public int getFrameWidth() {
+            return mFrameWidth;
+        }
+
+        public int getFrameHeight() {
+            return mFrameHeight;
+        }
+
+        public int getBitrate() {
+            return mBitrate;
+        }
+
+        public float getFramerate() {
+            return mFramerate;
+        }
+
+        public int getIFrameInterval() {
+            return mIframeinterval;
+        }
+
+        public int getPixelFormat() {
+            if (mPixelFormat > 0)
+                return mPixelFormat;
+            return MediaCodecInfo.CodecCapabilities.COLOR_FormatYUV420Planar;
+        }
+
+        public String getBaseEncoder() {
+            if (mEILParameters != null &&
+                    mEILParameters.containsKey(CONFIG_KEY_BASE_ENCODER))
+            {
+                return mEILParameters.get(CONFIG_KEY_BASE_ENCODER).toString();
+            }
+            return null;
+        }
+
+        // Map the EIL flags to their output. E.g., "qp_max" : 40
+        public HashMap<String, Object> getEilParameters() {
+            return mEILParameters;
+        }
+
+        public void setKeyValueEilParameter(String key, Object value) {
+            if (mEILParameters != null) {
+                mEILParameters.put(key, value);
+            }
+        }
+    }
+
+    public EncoderEIL(File file,
+                      int frameWidth,
+                      int frameHeight,
+                      int pixelFormat,
+                      Vector<Parameter> base_config,
+                      Vector<Parameter> eil_config,
+                      Statistics statistics,
+                      long referencePts,
+                      double refFrameTime) {
+        try {
+            // Initialize the Android EIL and I/O properties.
+            mEIL = new AndroidEIL();
+            mEncoderProperty = new EncoderProperty(frameWidth, frameHeight, pixelFormat, base_config, eil_config);
+            avPacketProperty = new ArrayList<>();
+
+            mInput = new Input(file, frameWidth, frameHeight);
+            mOutputFile = createEncodedStreamFile(file);
+            mOutputFile.getParentFile().mkdirs();
+            mOutput = FileChannel.open(mOutputFile.toPath(), StandardOpenOption.CREATE_NEW, StandardOpenOption.WRITE);
+
+            // Initialize encapp encoder's reference and statistics parameters.
+            mStats = statistics;
+            mReferencePts = referencePts;
+            mRefFrameTime = refFrameTime;
+
+            String outputFilename = mStats.getId() + ".mp4";
+            mMuxedFile = CliSettings.getWorkDir()  + "/" +  outputFilename; // final muxed mp4 file.
+
+            mStats.setEncodedfile(outputFilename);
+
+        } catch (RuntimeException ex) {
+            Log.e(TAG, "Failed to load Input", ex);
+        } catch (Exception ex) {
+            Log.e(TAG, "Unable to create output file", ex);
+        }
+    }
+
+    /**
+     * Encode input frames into an MP4 file.
+     */
+    public boolean run() throws IOException {
+        boolean ret = false;
+
+        initEncoder();
+
+        // We will need the reference pts and frame time for encoding and muxing. Ensure they are set.
+        if (mReferencePts == 0 || mRefFrameTime == 0) {
+            Log.e(TAG, "Reference pts or frame time not set");
+            return ret;
+        }
+
+        try {
+            while (!mIsEOS) {
+                encode(mReferencePts, mRefFrameTime);
+                pumpOutput();
+            }
+            mOutput.close();
+        } catch (RuntimeException | IOException ex) {
+            Log.e(TAG, "Encoding failed:", ex);
+        }
+
+        // If the base codec is x264, use the libavformat muxer. Otherwise use MediaMuxer.
+        String baseCodec = mEncoderProperty.getBaseEncoder();
+        if (baseCodec.equals(CODEC_X264)){
+            ret = libAVMuxerWrite();
+        } else if (baseCodec.equals(CODEC_MEDIACODEC_H264)) {
+            ret = mediaMuxerWrite(mReferencePts, mRefFrameTime);
+        } else {
+            Log.e(TAG, baseCodec + " is not supported");
+        }
+
+        if (mEIL != null) {
+            mEIL.release();
+        }
+
+        return ret;
+    }
+
+    /**
+     * Initializes libavformat muxer and convert the lcevc encoded stream to mp4.
+     * Currently valid for x264 only.
+     */
+    private boolean libAVMuxerWrite() {
+        AVFormatContext formatContext = avformat_alloc_context();
+        if (formatContext == null) {
+            Log.e(TAG, "Could not allocate format context.");
+            return false;
+        }
+
+        AVOutputFormat outputFormat = av_guess_format(null, getMuxedFile(), null);
+        if (outputFormat == null) {
+            Log.e(TAG, "Could not guess output format.");
+            return false;
+        }
+        formatContext.oformat(outputFormat);
+
+        AVStream stream = avformat_new_stream(formatContext, null);
+        if (stream == null) {
+            Log.e(TAG, "Could not create new stream.");
+            return false;
+        }
+
+        AVCodec codec = avcodec_find_encoder(AV_CODEC_ID_H264);
+        if (codec == null) {
+            Log.e(TAG, "H.264 encoder not found.");
+            return false;
+        }
+
+        AVCodecContext codecContext = avcodec_alloc_context3(codec);
+        if (codecContext == null) {
+            Log.e(TAG, "Could not allocate codec context.");
+            return false;
+        }
+
+        codecContext.codec_id(AV_CODEC_ID_H264);
+        codecContext.codec_type(AVMEDIA_TYPE_VIDEO);
+        codecContext.bit_rate(mEncoderProperty.getBitrate());
+        codecContext.framerate(av_make_q((int) mEncoderProperty.getFramerate(), 1)); // denomenator of 1
+        codecContext.pix_fmt(AV_PIX_FMT_YUV420P);
+        codecContext.time_base(av_make_q(1, (int) mEncoderProperty.getFramerate()));  // numerator of 1
+
+        if (mEIL != null) {
+            codecContext.width(mEIL.getBaseWidth());
+            codecContext.height(mEIL.getBaseHeight());
+        }
+
+
+        if ((formatContext.oformat().flags() & AVFMT_GLOBALHEADER) != 0) {
+            codecContext.flags(codecContext.flags() | AV_CODEC_FLAG_GLOBAL_HEADER);
+        }
+
+        if (avcodec_open2(codecContext, codec, (PointerPointer) null) < 0) {
+            Log.e(TAG, "Could not open codec.");
+            return false;
+        }
+
+        if (avcodec_parameters_from_context(stream.codecpar(), codecContext) < 0) {
+            Log.e(TAG, "Failed to copy codec parameters.");
+            return false;
+        }
+
+        if ((formatContext.oformat().flags() & AVFMT_NOFILE) == 0) {
+            AVIOContext pb = new AVIOContext(null);
+
+            if (avio_open(pb, getMuxedFile(), AVIO_FLAG_WRITE) < 0) {
+                Log.e(TAG, "Could not open output file.");
+                return false;
+            }
+            formatContext.pb(pb);
+        }
+
+        if (avformat_write_header(formatContext, (PointerPointer) null) < 0) {
+            Log.e(TAG, "Error writing MP4 header.");
+            return false;
+        }
+
+        Log.d(TAG,"MP4 header written successfully.");
+
+        // Create AVPacket for reading and writing
+        AVPacket avPacket = av_packet_alloc();
+        av_init_packet(avPacket);
+
+        for (AVPacketProperty packet : avPacketProperty) {
+            BytePointer bytePointer = new BytePointer(packet.getSize());
+
+            bytePointer.put(packet.getPacket(), 0, packet.getSize());
+            avPacket.data(bytePointer);
+            avPacket.size(packet.getSize());
+
+            // Set PTS/DTS values (this is crucial for proper synchronization)
+            avPacket.pts(av_rescale_q(packet.getPts(), codecContext.time_base(), stream.time_base()));
+            avPacket.dts(packet.getDts());
+
+            // Mux the avPacket into the MP4 container
+            if (av_interleaved_write_frame(formatContext, avPacket) < 0) {
+                Log.e(TAG, "Error writing avPacket.");
+                return false;
+            }
+        }
+
+        // Write trailer (finalizing MP4 file)
+        if (av_write_trailer(formatContext) < 0) {
+            Log.e(TAG, "Error writing trailer.");
+        }
+
+        // Cleanup resources
+        avcodec_free_context(codecContext);
+        avformat_free_context(formatContext);
+        av_packet_free(avPacket);
+
+        Log.d(TAG, "Muxing complete!");
+        return true;
+    }
+
+    /**
+     * Convert the lcevc encoded stream to mp4 using MediaMuxer.
+     * Currently valid for mediacodec only.
+     */
+    private boolean mediaMuxerWrite(long referencePts, double refFrameTime) throws IOException {
+        MediaMuxer muxer = new MediaMuxer(getMuxedFile(), MediaMuxer.OutputFormat.MUXER_OUTPUT_MPEG_4);
+
+        if(muxer == null) {
+            Log.e(TAG, "Failed to initialize MediaMuxer");
+            return false;
+        }
+
+        MediaFormat format = MediaFormat.createVideoFormat(MediaFormat.MIMETYPE_VIDEO_AVC,
+                mEIL.getBaseWidth(),
+                mEIL.getBaseHeight());
+
+        if (format == null) {
+            Log.e(TAG, "Failed to create video format");
+            return false;
+        }
+
+        format.setInteger(MediaFormat.KEY_WIDTH, mEIL.getBaseWidth());
+        format.setInteger(MediaFormat.KEY_HEIGHT, mEIL.getBaseHeight());
+        format.setInteger(MediaFormat.KEY_BIT_RATE, mEncoderProperty.getBitrate());
+        format.setFloat(MediaFormat.KEY_FRAME_RATE, mEncoderProperty.getFramerate());
+        format.setInteger(MediaFormat.KEY_COLOR_FORMAT, mEncoderProperty.getPixelFormat());
+
+        if (mEncoderProperty.getIFrameInterval() > 0)
+            format.setInteger(MediaFormat.KEY_I_FRAME_INTERVAL, mEncoderProperty.getIFrameInterval());
+
+        if (avPacketProperty == null || avPacketProperty.isEmpty())
+        {
+            Log.e(TAG, "No encoded output packet is available");
+            return false;
+        }
+
+
+        MediaCodec.BufferInfo bufferInfo = new MediaCodec.BufferInfo();
+        int videoTrackIndex = -1;
+        int currentFrameID = 0;
+
+        final String spsKey = "csd-0";
+        final String ppsKey = "csd-1";
+
+        for (AVPacketProperty packet : avPacketProperty) {
+            // sps and pps only need to be set once.
+            if ((!format.containsKey(spsKey)) ||
+                    (!format.containsKey(ppsKey))) {
+                try {
+                    ByteBuffer sps = ByteBuffer.wrap(extractSpsPps(packet.getPacket(), Encoder.H264_NALU_TYPE_SPS));
+                    ByteBuffer pps = ByteBuffer.wrap(extractSpsPps(packet.getPacket(), Encoder.H264_NALU_TYPE_PPS));
+                    format.setByteBuffer(spsKey, sps);
+                    format.setByteBuffer(ppsKey, pps);
+                } catch (Exception e) {
+                    Log.e(TAG, "Failed to extract the NAL SPS and PPS ", e);
+                }
+
+                videoTrackIndex = muxer.addTrack(format);
+                muxer.start();
+            }
+
+            ByteBuffer buffer = ByteBuffer.wrap(packet.getPacket());
+            bufferInfo.offset = 0;
+            bufferInfo.size = packet.getSize();
+            // Use reference pts for MediaMuxer.
+            bufferInfo.presentationTimeUs = Encoder.computePresentationTimeUs(referencePts, currentFrameID++, refFrameTime);
+
+            boolean isKeyFrame = Encoder.checkIfKeyFrame(packet.getPacket(), Encoder.SyntaxType.H264);
+
+            if (isKeyFrame)
+                bufferInfo.flags = MediaCodec.BUFFER_FLAG_KEY_FRAME;
+
+            if(videoTrackIndex != -1) {
+                buffer.position(bufferInfo.offset);
+                buffer.limit(bufferInfo.offset + bufferInfo.size);
+                muxer.writeSampleData(videoTrackIndex, buffer, bufferInfo);
+            }
+            else {
+                Log.e(TAG, "Failed to initialize the MediaMuxer");
+                return false;
+            }
+        }
+
+        muxer.release();
+
+        return true;
+    }
+
+
+    /**
+     * Extracts the NAL unit from the encoded stream based on the nal type.
+     */
+    public static byte[] extractSpsPps(byte[] encodedStream, int nalType) {
+        for (int i = 0; i < encodedStream.length - 4; i++) {
+            // Check for NAL unit start code: 0x00 0x00 0x00 0x01 or 0x00 0x00 0x01.
+            int nalStartIndex = findNalStartCodePrefixIndex(encodedStream, i);
+            if (nalStartIndex < encodedStream.length)  {
+                int startCodeLength = findNalStartCodePrefixLength(encodedStream, nalStartIndex);
+                // Check if the NAL unit is of the desired type (e.g., SPS or PPS)
+                if (getNalUnitType(encodedStream, nalStartIndex) == nalType) {
+                    // Find the next start code or end of stream
+                    int startPosition = i + startCodeLength;
+                    int end = encodedStream.length;
+                    for (int j = startPosition; j < encodedStream.length - 4; j++) {
+                        end = findNalStartCodePrefixIndex(encodedStream, j);
+                        if (end != encodedStream.length)
+                            break;
+                    }
+                    // Extract the NAL unit byte array
+                    return Arrays.copyOfRange(encodedStream, startPosition, end);
+                }
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Finds the bitstream index where the NALU start code prefix (0x00 0x00 0x00 0x01 or 0x00 0x00 0x01) begins.
+     */
+    private static int findNalStartCodePrefixIndex(byte[] data, int startPosition) {
+        if ((data[startPosition] == 0x00 && data[startPosition + 1] == 0x00 && data[startPosition + 2] == 0x00 && data[startPosition + 3] == 0x01) ||
+                data[startPosition] == 0x00 && data[startPosition + 1] == 0x00 && data[startPosition + 2] == 0x01) {
+            return startPosition;
+        }
+        return data.length;
+    }
+
+    /**
+     * Find the NALU start code prefix length from the bitstream.
+     * In H264, the start code prefix length is either 4 (0x00 0x00 0x00 0x01) or 3 (0x00 0x00 0x01).
+     */
+    private static int findNalStartCodePrefixLength(byte[] data, int startCodeIndex) {
+        return ((data[startCodeIndex + 2] == 0x01)? 3 : 4);
+    }
+
+    private static int getNalUnitType(byte[] data, int startCodeIndex) {
+        int nalStartCodeLength = findNalStartCodePrefixLength(data, startCodeIndex);
+        return data[startCodeIndex + nalStartCodeLength] & 0x1F;
+    }
+
+    /**
+     Encode each individual video frame.
+     */
+    private void encode(long referencePts, double refFrameTime) throws IOException {
+        // Attempt to get a picture object from the EIL
+        long picture = mEIL.getPicture();
+
+        // If the EIL has a picture available we can send an image to the encoder for encoding
+        if (picture != EIL.INVALID_PICTURE) {
+            ByteBuffer inputFrame = mInput.nextFrame();
+            if (inputFrame == null) {
+                throw new RuntimeException("Failed to get input");
+            }
+
+            int currentFrameID = mInput.getFramesRead() - 1;
+
+            // Calculate presentation time for this frame and signal to the statistics class.
+            long pts = Encoder.computePresentationTimeUs(referencePts, currentFrameID, refFrameTime);
+            FrameInfo info = mStats.startEncodingFrame(pts, currentFrameID);
+
+            inputFrame.flip();
+            if (!mEIL.encode(picture, inputFrame)) {
+                throw new RuntimeException("Unable to encode frame");
+            }
+
+            // Signal that frame has been encoded.
+            mStats.stopEncodingFrame(info.getPts(), info.getSize(), info.isIFrame());
+        }
+
+        // Once we've read all the frames, flush the encoder
+        if (mInput.isFinished()) {
+            mIsEOS = true;
+
+            // Flush the encoder by sending a null payload
+            if (!mEIL.encode(0, null)) {
+                throw new RuntimeException("Unable to flush encoder");
+            }
+        }
+    }
+
+    /**
+     Extract output frame and populate statistics
+     */
+    private void pumpOutput() throws IOException {
+        // Adjust timestamp by 2 to align EIL encoder output with MediaCodec timing.
+        int timestampSteppings = 2;
+        EIL.OutputBuffer output;
+        int pts = 0;
+        int dts = 0;
+        int size = 0;
+
+        while ((output = mEIL.getOutput()) != null) {
+            pts = (int) (output.mPts / timestampSteppings);
+            dts = (int) (output.mDts / timestampSteppings);
+            size = output.mBuffer.limit();
+
+            // Set output buffer flags
+            ArrayList<FrameInfo> encodedFramesStats = mStats.getEncodedFrames();
+            if (mReceivedOutputBuffer < mStats.getEncodedFrameCount()) {
+                FrameInfo frameInfo = encodedFramesStats.get(mReceivedOutputBuffer++);
+
+                if (output.mBuffer != null && output.mBuffer.hasRemaining()) {
+                    byte[] outputBuffer = new byte[output.mBuffer.remaining()];
+                    output.mBuffer.get(outputBuffer);
+
+                    boolean isKeyFrame = Encoder.checkIfKeyFrame(outputBuffer, Encoder.SyntaxType.H264);
+                    frameInfo.isIFrame(isKeyFrame);
+                    frameInfo.setSize(size);
+                }
+            }
+
+            // Flip the output buffer for reading.
+            output.mBuffer.flip();
+
+            // Write the elementary stream file.
+            mOutput.write(output.mBuffer);
+
+            avPacketProperty.add(new AVPacketProperty(output.mBuffer, pts, dts, size));
+            mEIL.releaseOutput(output);
+        }
+    }
+
+    /**
+     Initialize the LCEVC encoder with the base and eil encoder parameters.
+     Prioritize the direct protobuf paramters over the json config file.
+     */
+    private void initEncoder() throws RuntimeException {
+        // Get the base encoder parameters
+        int width = mEncoderProperty.getFrameWidth();
+        int height = mEncoderProperty.getFrameHeight();
+        int bitrate = mEncoderProperty.getBitrate();
+        float iFrameInterval = mEncoderProperty.getIFrameInterval();
+        float frameRate = mEncoderProperty.getFramerate();
+
+        // Set key parameters with MediaFormat (bitrate...)
+        MediaFormat format = MediaFormat.createVideoFormat(MediaFormat.MIMETYPE_VIDEO_AVC, width, height);
+        format.setInteger(MediaFormat.KEY_COLOR_FORMAT, mEncoderProperty.getPixelFormat());
+
+        if (frameRate > 0) {
+            format.setFloat(MediaFormat.KEY_FRAME_RATE, frameRate);
+        }
+        if (bitrate > 0) {
+            format.setInteger(MediaFormat.KEY_BIT_RATE, bitrate);
+        }
+
+        if (iFrameInterval > 0) {
+            format.setFloat(MediaFormat.KEY_I_FRAME_INTERVAL, iFrameInterval);
+        }
+
+        String pathToJsonConfig = "";
+        String eilConfigJson = "";
+
+        HashMap<String, Object> eilParameters = mEncoderProperty.getEilParameters();
+
+        // Set base encoder (e.g., x264)
+        if (eilParameters.containsKey(CONFIG_KEY_BASE_ENCODER)) {
+            String baseCodec = eilParameters.get(CONFIG_KEY_BASE_ENCODER).toString();
+            format.setString(AndroidEIL.KEY_BASE_ENCODER, baseCodec);
+        }
+
+        // Gop length cannot be passed to the json config buffer.
+        // Must be set with MediaFormat.
+        if (eilParameters.containsKey(CONFIG_KEY_GOP_LENGTH)) {
+            int gopLength = Integer.parseInt(eilParameters.get(CONFIG_KEY_GOP_LENGTH).toString());
+            format.setInteger(AndroidEIL.KEY_GOP_LENGTH, gopLength);
+        }
+
+        // Convert the other eil parameters to json for LCEVC encoding.
+        eilConfigJson = convertEncoderMapToJsonString(eilParameters);
+        Log.d(TAG, "Parsing LCEVC EIL parameters from protobuf parameters");
+        Log.d(TAG, eilConfigJson);
+
+        // Check if a json config file has been passed.
+        if (eilParameters.containsKey(CONFIG_KEY_JSON)) {
+            pathToJsonConfig = eilParameters.get(CONFIG_KEY_JSON).toString();
+
+            String[] splitFilePath = pathToJsonConfig.split("/");
+            pathToJsonConfig = CliSettings.getWorkDir() + "/" + splitFilePath[splitFilePath.length - 1];
+        }
+
+        // Extract the eil parameters from the json file only if no direct parameter has been passed.
+        if (!pathToJsonConfig.isEmpty() &&
+                (eilParameters.size() == 1 && eilParameters.containsKey(CONFIG_KEY_JSON))) {
+            try {
+                String content = new String(Files.readAllBytes(Paths.get(pathToJsonConfig)));
+                JSONObject jsonObject = new JSONObject(content);
+
+                if (jsonObject.has(CONFIG_KEY_BASE_ENCODER)) {
+                    Object value = jsonObject.get(CONFIG_KEY_BASE_ENCODER);
+                    String baseCodec = value.toString();
+                    format.setString(AndroidEIL.KEY_BASE_ENCODER, baseCodec);
+
+                    // Store base codec in central property class
+                    mEncoderProperty.setKeyValueEilParameter(CONFIG_KEY_BASE_ENCODER, baseCodec);
+                    // Do not pass to json buffer.
+                    jsonObject.remove(CONFIG_KEY_BASE_ENCODER);
+                }
+
+                if (jsonObject.has(CONFIG_KEY_GOP_LENGTH)) {
+                    Object value = jsonObject.get(CONFIG_KEY_GOP_LENGTH);
+                    int gopLength = Integer.parseInt(value.toString());
+                    format.setInteger(AndroidEIL.KEY_GOP_LENGTH, gopLength);
+
+                    // Store base codec in central property class
+                    mEncoderProperty.setKeyValueEilParameter(CONFIG_KEY_GOP_LENGTH, gopLength);
+                    // Do not pass to json buffer.
+                    jsonObject.remove(CONFIG_KEY_GOP_LENGTH);
+                }
+
+                eilConfigJson = jsonObject.toString();
+
+                Log.d(TAG, "Parsing LCEVC EIL parameters from " + pathToJsonConfig);
+                Log.d(TAG, eilConfigJson);
+            } catch (IOException e) {
+                Log.e(TAG, "Unable to parse the JSON file", e);
+            } catch (JSONException e) {
+                throw new RuntimeException(e);
+            }
+
+        }
+
+        // eilConfigJson will never be empty due to the brackets ({})
+        if (eilConfigJson.length() > 2) {
+            try {
+                ByteBuffer jsonBuffer = ByteBuffer.wrap(eilConfigJson.getBytes("UTF8"));
+                format.setByteBuffer("csd-0", jsonBuffer);
+            } catch (Exception e) {
+                Log.e(TAG, "Could not set encode JSON EIL parameters", e);
+            }
+        }
+
+        Log.d(TAG, "Configuring LCEVC EIL with " + format);
+
+        if (!mEIL.configure(format, null)) {
+            throw new RuntimeException("Failed to configure LCEVC encoder");
+        }
+
+    }
+
+    /**
+     Convert all LCEVC EIL parameters to a Json format.
+     E.g., "{\"key1\":\"value1\",\"key2\":\"value2\"}"
+     */
+    public static String convertEncoderMapToJsonString(HashMap<String, Object> eilParameters) {
+        if (eilParameters.isEmpty()) {
+            return "";
+        }
+
+        StringBuilder jsonBuilder = new StringBuilder();
+        jsonBuilder.append("{");
+
+        Iterator<Map.Entry<String, Object>> eilParametersIt = eilParameters.entrySet().iterator();
+        while (eilParametersIt.hasNext()) {
+            Map.Entry<String, Object> entry = eilParametersIt.next();
+            String key = entry.getKey();
+            Object value = entry.getValue();
+
+            // Do not append the base encoder, gop_length and json config path to the json string.
+            if (Objects.equals(key, CONFIG_KEY_BASE_ENCODER) ||
+                    Objects.equals(key, CONFIG_KEY_GOP_LENGTH) ||
+                    Objects.equals(key, CONFIG_KEY_JSON)) {
+                continue;
+            }
+
+            // Append the key in JSON format: "key":
+            jsonBuilder.append("\"").append(key).append("\":");
+
+            // Only wrap the string values in quotes.
+            if (value instanceof Integer ||
+                    value instanceof Double ||
+                    value instanceof Float ||
+                    value instanceof Long ||
+                    value instanceof Boolean) {
+                jsonBuilder.append(value);
+            } else {
+                jsonBuilder.append("\"").append(value).append("\"");
+            }
+
+            // Add a comma between pairs, but not after the last pair.
+            if (eilParametersIt.hasNext()) {
+                jsonBuilder.append(",");
+            }
+        }
+
+        jsonBuilder.append("}");
+
+        return jsonBuilder.toString();
+    }
+
+    /**
+     Create the file to be used to store the encoded elementary stream.
+     */
+    public File createEncodedStreamFile(File inputFile) {
+        String fileName = "encoded.es";
+        SimpleDateFormat now = new SimpleDateFormat("yyyyMMdd_HHmmss", Locale.getDefault());
+        String nowString = now.format(new Date());
+        String inputName = inputFile.getName().replace(".", "_");
+
+        return Paths
+                .get(CliSettings.getWorkDir(), "output", inputName + "_" + nowString, fileName)
+                .toFile();
+
+    }
+
+    /**
+     Return path to the muxed file.
+     */
+    public String getMuxedFile() {
+        return mMuxedFile;
+    }
+
+    /**
+     Return the encoded and compressed elementary stream.
+     */
+    public File getElementaryStream() {
+        if (mOutputFile.exists()) {
+            return mOutputFile;
+        }
+        else {
+            return null;
+        }
+    }
+}

--- a/app/src/main/java/com/facebook/encapp/MainActivity.java
+++ b/app/src/main/java/com/facebook/encapp/MainActivity.java
@@ -327,13 +327,13 @@ public class MainActivity extends AppCompatActivity implements BatteryStatusList
         }
 
 
-        TestSuite test_suite = null;
+        TestSuite testSuite = null;
         try {
             if (mExtraData.containsKey(CliSettings.TEST_CONFIG)) {
-                String test_path = mExtraData.getString(CliSettings.TEST_CONFIG);
-                Log.d(TAG, "test_path: " + test_path);
+                String testPath = mExtraData.getString(CliSettings.TEST_CONFIG);
+                Log.d(TAG, "testPath: " + testPath);
                 // read the test file
-                File file = new File(test_path);
+                File file = new File(testPath);
                 int length = (int) file.length();
                 FileInputStream fis = new FileInputStream(file);
                 byte[] bytes = new byte[length];
@@ -342,34 +342,34 @@ public class MainActivity extends AppCompatActivity implements BatteryStatusList
 
                 TestSuite.Builder tests_builder = TestSuite.newBuilder();
                 TextFormat.getParser().merge(test_path_contents, tests_builder);
-                test_suite = tests_builder.build();
+                testSuite = tests_builder.build();
 
 
                 // Log.d(TAG, "data: " + Files.readAllBytes(basename));
                 // ERROR
-                if (test_suite.getTestList().size() <= 0) {
+                if (testSuite.getTestList().size() <= 0) {
                     Log.e(TAG, "Failed to read test");
                     return;
                 }
-                if (test_suite == null) {
+                if (testSuite == null) {
                     Log.d(TAG, "No test case");
                     return;
                 }
 
                 // Get test setup params
                 // cli have preference
-                Test test0 = test_suite.getTestList().get(0);
+                Test test0 = testSuite.getTestList().get(0);
                 if (test0.hasTestSetup() && mUIHoldtimeSec == 0) {
                     TestSetup setup = test0.getTestSetup();
                     if (setup.hasUiholdSec()) {
                         mUIHoldtimeSec = setup.getUiholdSec();
                     }
                 }
-                
+
                 int nbrViews = 0;
                 boolean hasCameraPreview = false;
                 // Prepare views for visualization
-                for (Test test : test_suite.getTestList()) {
+                for (Test test : testSuite.getTestList()) {
                     nbrViews += countInputPreviews(test);
                     showCameraPreview(test);
                 }
@@ -400,9 +400,9 @@ public class MainActivity extends AppCompatActivity implements BatteryStatusList
                 boolean cameraStarted = false;
                 int pursuit = -1;// TODO: pursuit
                 while (!mPursuitOver) {
-                    Log.d(TAG, "** Starting tests, " + test_suite.getTestCount() +
+                    Log.d(TAG, "** Starting tests, " + testSuite.getTestCount() +
                             " number of combinations (parallels not counted) **");
-                    for (Test test : test_suite.getTestList()) {
+                    for (Test test : testSuite.getTestList()) {
                         // Do not start if power level is low
                         if (test.hasTestSetup() && test.getTestSetup().getIgnorePowerStatus()) {
                             Log.w(TAG, "Power level checks are overridden. Measurements will run regardless of power status.");
@@ -519,8 +519,8 @@ public class MainActivity extends AppCompatActivity implements BatteryStatusList
                                             // some errors here
                                             p.join(WAIT_TIME_MS);
                                             if (p.getState() == Thread.State.WAITING ||
-                                                p.getState() == Thread.State.TIMED_WAITING ||
-                                                p.getState() == Thread.State.BLOCKED) {
+                                                    p.getState() == Thread.State.TIMED_WAITING ||
+                                                    p.getState() == Thread.State.BLOCKED) {
                                                 Log.d(TAG, p.getName() + " is still waiting (" + p.getState() + ").\nThis is probably not correct.\nTry to release");
                                                 for (Encoder coder: mEncoderList) {
                                                     Log.d(TAG, "Force release");
@@ -706,6 +706,10 @@ public class MainActivity extends AppCompatActivity implements BatteryStatusList
                 // TODO: how to integrate with the rest?
                 Log.d(TAG, "0. Custom encoder");
                 coder = new CustomEncoder(test, this.getFilesDir().getPath());
+            } else if (test.getConfigure().getCodec().startsWith("lcevc")) {
+
+                Log.d(TAG, "1. LCEVC decode");
+                coder = new LcevcEncoder(test);
             } else if (!surface && deviceDecode && !deviceEncode) {
 
                 Log.d(TAG, "1. Simple buffer decode");

--- a/app/src/main/java/com/facebook/encapp/SurfaceEncoder.java
+++ b/app/src/main/java/com/facebook/encapp/SurfaceEncoder.java
@@ -306,14 +306,14 @@ class SurfaceEncoder extends Encoder implements VsyncListener {
                                 mDropNext = false;
                             } else {
                                 mFrameSwapSurface.dropNext(false);
-                                long ptsUsec = 0;
+                                long presentationTimeUs = 0;
                                 if (mUseCameraTimestamp) {
                                     // Use the camera provided timestamp
-                                    ptsUsec = mPts + (long) (timestampUsec - mFirstFrameTimestampUsec);
+                                    presentationTimeUs = mPts + (long) (timestampUsec - mFirstFrameTimestampUsec);
                                 } else {
-                                    ptsUsec = computePresentationTimeUsec(mInFramesCount, mRefFrameTime);
+                                    presentationTimeUs = computePresentationTimeUs(mPts, mInFramesCount, mRefFrameTime);
                                 }
-                                mStats.startEncodingFrame(ptsUsec, mInFramesCount);
+                                mStats.startEncodingFrame(presentationTimeUs, mInFramesCount);
                                 mFramesAdded++;
                             }
                             mInFramesCount++;
@@ -484,7 +484,7 @@ class SurfaceEncoder extends Encoder implements VsyncListener {
             FileReader fileReader, MediaCodec codec, ByteBuffer byteBuffer, int frameCount, int flags, int size) {
         byteBuffer.clear();
         int read = fileReader.fillBuffer(byteBuffer, size);
-        long ptsUsec = computePresentationTimeUsec(mInFramesCount, mRefFrameTime);
+        long presentationTimeUs = computePresentationTimeUs(mPts, mInFramesCount, mRefFrameTime);
         setRuntimeParameters(mInFramesCount);
         mDropNext = dropFrame(mInFramesCount);
         mDropNext |= dropFromDynamicFramerate(mInFramesCount);
@@ -506,10 +506,10 @@ class SurfaceEncoder extends Encoder implements VsyncListener {
             }
 
             if (mFirstFrameTimestampUsec == -1) {
-                mFirstFrameTimestampUsec = ptsUsec;
+                mFirstFrameTimestampUsec = presentationTimeUs;
             }
-            mOutputMult.newBitmapAvailable(mBitmap, ptsUsec);
-            mStats.startEncodingFrame(ptsUsec, frameCount);
+            mOutputMult.newBitmapAvailable(mBitmap, presentationTimeUs);
+            mStats.startEncodingFrame(presentationTimeUs, frameCount);
         } else {
             Log.d(TAG, "***************** FAILED READING SURFACE ENCODER ******************");
             return -1;

--- a/app/src/main/java/com/facebook/encapp/utils/Statistics.java
+++ b/app/src/main/java/com/facebook/encapp/utils/Statistics.java
@@ -259,6 +259,10 @@ public class Statistics {
         return mEncodingFrames.size();
     }
 
+    public ArrayList<FrameInfo> getEncodedFrames() {
+        return mEncodingFrames;
+    }
+
     public int getDecodedFrameCount() {
         return mDecodingFrames.size();
     }

--- a/build.gradle
+++ b/build.gradle
@@ -21,6 +21,7 @@ allprojects {
     repositories {
         google()
         jcenter()
+        mavenLocal()
     }
 }
 

--- a/lcevc/x264/README.md
+++ b/lcevc/x264/README.md
@@ -1,0 +1,21 @@
+# x264 build
+Set ndk path and build tools first, e.g.
+```
+# for MacOs
+export HOST_TAG=darwin-x86_64
+export NDK="/System/Volumes/Data/Users/XXX/Library/Android/sdk/ndk-bundle/"
+```
+
+Run script
+```
+./build.sh 
+```
+Optional: Run with `--clean` to clean build (executes `make clean`).
+
+
+# Testing
+The build library will be copied to lcevc/x264/libs
+
+```
+python3 encapp.py run tests/lcevc_x264.pbtxt --lcevc
+```

--- a/lcevc/x264/build.sh
+++ b/lcevc/x264/build.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+
+# 1. Setup environments
+export TOOLCHAIN=$NDK/toolchains/llvm/prebuilt/$HOST_TAG
+export CC=$TOOLCHAIN/bin/aarch64-linux-android21-clang
+export CXX=$TOOLCHAIN/bin/aarch64-linux-android21-clang++
+
+# 2. Set pahs to x264 submodule, jniLibs, shared lib output and v163 commit hash.
+CURR_DIR=$(pwd)
+MODULES_DIR=$(realpath ../../modules/x264)
+JNI_LIBS_DIR=$(realpath ../../app/src/main/jniLibs)
+OUTPUT_DIR=$MODULES_DIR/android/arm64-v8a
+TARGET_COMMIT=5db6aa6c
+
+# 3. Navigate to modules/x264, update gitmodule and switch to HEAD with v163
+cd $MODULES_DIR
+echo "Updating x264 submodule..."
+
+# initialize the submodule.
+git submodule update --init
+
+# Check if the submodule has any commits
+if ! git rev-parse HEAD &>/dev/null; then
+    echo "x264 submodule is empty. Cloning the correct commit..."
+    git fetch origin --quiet || { echo "Failed to fetch x264 submodule."; exit 1; }
+fi
+
+# Store the current HEAD of the submodule
+CURRENT_HEAD=$(git rev-parse HEAD)
+
+git checkout $TARGET_COMMIT --quiet || { echo "Failed to switch to commit $TARGET_COMMIT"; exit 1; }
+
+# 4. Build shared x264 library.
+function build_libx264_arm64-v8a
+{
+  ./configure \
+  --prefix=$OUTPUT_DIR \
+  --enable-shared \
+  --enable-pic \
+  --disable-asm \
+  --disable-opencl \
+  --disable-cli \
+  --host=aarch64-linux \
+  --cross-prefix=$TOOLCHAIN/bin/aarch64-linux-android- \
+  --sysroot=$TOOLCHAIN/sysroot \
+
+  if [ "$1" == "--clean" ]; then
+      echo "Flag '--clean' detected. Running 'make clean'..."
+      make clean
+  fi
+
+  make
+  make install
+}
+echo "Building libx264 version 163..."
+build_libx264_arm64-v8a "$1"
+
+# 5. Switch back to x264 version 164.
+git checkout $CURRENT_HEAD --quiet || { echo "Failed to switch to commit $CURRENT_HEAD"; exit 1; }
+
+# 6. Copy shared x264 library to lcevc/x264 libs.
+mkdir -p $CURR_DIR/libs/arm64-v8a
+cp $OUTPUT_DIR/lib/libx264.so $CURR_DIR/libs/arm64-v8a

--- a/scripts/encapp.py
+++ b/scripts/encapp.py
@@ -695,6 +695,35 @@ def run_codec_tests_file(
             path = f"{local_workdir}/{valid_path(test.common.id)}.pbtxt"
             configfile_write(suite, path)
             files_to_push |= {path}
+
+    if options.lcevc:
+        if debug:
+            print("Verifying LCEVC parameters")
+        assert (
+            test.configure.codec == "lcevc_h264"
+        ), f'error: Codec" {test.configure.codec}" is invalid. Only lcevc_h264 is supported at the moment'
+
+        for param in test.configure.parameter:
+            if param.key == "base_encoder":
+                assert (
+                    param.value == "mediacodec_h264" or param.value == "x264"
+                ), f'Base Encoder "{param.value}" is invalid. Only mediacodec_h264 and x264 are supported at the moment'
+            if param.key == "eil_params_path":
+                assert (
+                    param.value.endswith(".json")
+                ), f'eil_params_path must point to a JSON file'
+                json_file_path = os.path.abspath(param.value)
+
+                if not encapp_tool.adb_cmds.push_file_to_device(
+                    json_file_path,
+                    serial,
+                    options.device_workdir,
+                    False,
+                    debug
+                ):
+                    abort_test(local_workdir, f"Error copying {json_file_path} to {serial}")
+
+
     # Save the complete test if updated
     if updated:
         # remove any older pbtxt in existence
@@ -2182,6 +2211,12 @@ def add_args(parser):
         help=f"Split large files in chunks. Default chunk size is {encapp_tool.adb_cmds.SPLIT_SIZE_BYTES} bytes",
     )
 
+    parser.add_argument(
+        "--lcevc",
+        action="store_true",
+        help="Verify lcevc test parameters and copy the necessary eil config files"
+    )
+
 
 input_args = {
     # generic
@@ -2948,6 +2983,7 @@ def main(argv):
         if not options.dry_run:
             # first clear out old result
             remove_encapp_gen_files(serial, options.device_workdir, options.debug)
+
         result_ok, result_json = codec_test(options, model, serial, options.debug)
 
         global QUALITY_PROCESSES

--- a/scripts/encapp_quality.py
+++ b/scripts/encapp_quality.py
@@ -30,8 +30,10 @@ SCRIPT_ROOT_DIR = os.path.abspath(
 SCRIPT_PROTO_DIR = os.path.abspath(
     os.path.join(encapp_tool.app_utils.SCRIPT_DIR, "proto")
 )
+
 sys.path.append(SCRIPT_ROOT_DIR)
 sys.path.append(SCRIPT_PROTO_DIR)
+
 import tests_pb2 as tests_definitions  # noqa: E402
 
 PSNR_RE = re.compile(
@@ -491,6 +493,16 @@ def run_quality(test_file, options, debug):
             failed["error"] = "Not an encapp file"
             return failed
 
+        # check if the encoder is lcevc
+        use_lcevc = False
+        codec = results.get("test", {}).get("configure", {}).get("codec")
+        if codec is None:
+            print(f"ERROR, 'codec' not found in 'test -> configure' for {test_file}")
+        elif debug:
+            print(f"Codec: {codec}")
+        if codec.startswith("lcevc"):
+            use_lcevc = True
+
     # read device info results
     device_info_file = os.path.join(os.path.dirname(test_file), "device.json")
     if os.path.exists(device_info_file):
@@ -549,7 +561,7 @@ def run_quality(test_file, options, debug):
 
     video_info = None
     try:
-        video_info = encapp_tool.ffutils.get_video_info(encodedfile, debug)
+        video_info = encapp_tool.ffutils.get_video_info(encodedfile, debug, use_lcevc)
     except:
         print("Failed to parse with ffprobe")
         video_info = None

--- a/scripts/encapp_tool/ffutils.py
+++ b/scripts/encapp_tool/ffutils.py
@@ -76,15 +76,29 @@ def video_is_y4m(videofile):
     return extension == ".y4m"
 
 
-def get_video_info(videofile, debug=0):
-    assert os.path.exists(videofile), f"input video file {videofile} not exist"
-    assert os.path.isfile(videofile), f"input video file {videofile} is not a file"
-    assert os.access(
-        videofile, os.R_OK
-    ), f"input video file ({videofile}) is not readable"
+def get_video_info(videofile, debug=0, use_lcevc=False):
+    # Verify the file exists and is accessible
+    assert os.path.exists(videofile), f"Input video file {videofile} does not exist"
+    assert os.path.isfile(videofile), f"Input video file {videofile} is not a file"
+    assert os.access(videofile, os.R_OK), f"Input video file ({videofile}) is not readable"
+
+    # If use_lcevc is True, apply the "lcevc" filter and save the output
+    if use_lcevc:
+        video_dir = os.path.dirname(videofile)
+        lcevc_videofile = os.path.join(video_dir, f"lcevc_{os.path.basename(videofile)}")
+        ffmpeg_cmd = f"ffmpeg -i {videofile} -vf lcevc -y {lcevc_videofile}"
+        ret, stdout, stderr = encapp_tool.adb_cmds.run_cmd(ffmpeg_cmd, debug)
+
+        assert ret, f"Error: failed to apply LCEVC filter to file {videofile}: {stderr}"
+
+        # Update videofile to point to the LCEVC-encoded file for ffprobe analysis
+        videofile = lcevc_videofile
+
+    # Skip ffprobe if the video file is raw
     if video_is_raw(videofile):
         return {}
-    # check using ffprobe
+
+    # Analyze the file using ffprobe
     cmd = f"ffprobe -v quiet -select_streams v -show_streams {videofile}"
     ret, stdout, stderr = encapp_tool.adb_cmds.run_cmd(cmd, debug=debug)
     assert ret, f"error: failed to analyze file {videofile}: {stderr}"
@@ -93,7 +107,7 @@ def get_video_info(videofile, debug=0):
     return videofile_config
 
 
-def ffmpeg_transcode_raw(input_filepath, output_filepath, settings, debug):
+def ffmpeg_transcode_raw(input_filepath, output_filepath, settings, debug, use_lcevc=False):
     resolution = settings.get("output", {}).get(
         "resolution", settings.get("input", {}).get("resolution")
     )
@@ -115,6 +129,9 @@ def ffmpeg_transcode_raw(input_filepath, output_filepath, settings, debug):
         f"pad={pad_w}:{pad_h},"
         f"fps={str(settings.get('output', {}).get('framerate', settings.get('input', {}).get('framerate')))}"
     )
+    if use_lcevc:
+        filter_cmd += ",lcevc"
+
     if debug > 0:
         print(f"filter command {filter_cmd}")
     cmd = FFMPEG_SILENT + [
@@ -145,7 +162,7 @@ def ffmpeg_transcode_raw(input_filepath, output_filepath, settings, debug):
     assert ret, f"error: ffmpeg returned {stderr}"
 
 
-def ffmpeg_convert_to_raw(input_filepath, output_filepath, settings, debug):
+def ffmpeg_convert_to_raw(input_filepath, output_filepath, settings, debug, use_lcevc=False):
     resolution = settings.get("output", {}).get(
         "resolution", settings.get("input", {}).get("resolution")
     )
@@ -173,6 +190,9 @@ def ffmpeg_convert_to_raw(input_filepath, output_filepath, settings, debug):
 
     if framerate and float(framerate) > 0:
         filter_cmd = filter_cmd + f",fps={framerate}"
+
+    if use_lcevc:
+        filter_cmd += ",lcevc"
 
     if debug > 0:
         print(f"filter command {filter_cmd}")

--- a/tests/lcevc_json_config.pbtxt
+++ b/tests/lcevc_json_config.pbtxt
@@ -1,0 +1,20 @@
+test {
+    input {
+        filepath: "/tmp/akiyo_qcif.y4m"
+    }
+    common { 
+        id: "lcevc_json_config"
+        description: "V-Nova's LCEVC H264 encoding using json config"
+    }
+    configure {
+        codec: "lcevc_h264"
+        bitrate: "2000k"
+        i_frame_interval: 10
+
+        parameter {
+            key: "eil_params_path"
+            type: stringType
+            value: "/tmp/testConfig.json"
+        }
+    }
+}

--- a/tests/lcevc_mediacodec_h264.pbtxt
+++ b/tests/lcevc_mediacodec_h264.pbtxt
@@ -1,0 +1,20 @@
+test {
+    input {
+        filepath: "/tmp/akiyo_qcif.y4m"
+    }
+    common {
+        id: "lcevc_mediacodec"
+        description: "V-Nova's LCEVC Mediacodec H264 encoding"
+    }
+    configure {
+        codec: "lcevc_h264"
+        bitrate: "500 kbps"
+        framerate: 30
+        i_frame_interval: 3
+        parameter {
+            key: "base_encoder"
+            type: stringType
+            value: "mediacodec_h264"
+        }
+    }
+}

--- a/tests/lcevc_x264.pbtxt
+++ b/tests/lcevc_x264.pbtxt
@@ -1,0 +1,20 @@
+test {
+    input {
+        filepath: "/tmp/akiyo_qcif.y4m"
+    }
+    common {
+        id: "lcevc_x264"
+        description: "V-Nova's LCEVC x264 encoding"
+    }
+    configure {
+        codec: "lcevc_h264"
+        bitrate: "500 kbps"
+        framerate: 30
+        i_frame_interval: 10
+        parameter {
+            key: "base_encoder"
+            type: stringType
+            value: "x264"
+        }
+    }
+}


### PR DESCRIPTION
# Summary

This MR introduces support for LCEVC encoding using Mediacodec H264 and x264 base encoders. It leverages V-Nova's LCEVC SDK version 3.13.2 and integrates the necessary pipeline for Mediacodec and x264 workflows into encapp v1.23.

---

# Key Changes

## LCEVC Encoding Support

- Added LCEVC encoding support via SDK 3.13.2.

### Base encoders supported:
- `mediacodec_h264` 
- `x264`

---

# Dependencies

- Added build script for `libx264`, using commit hash `5db6aa6c` (v163).
- Added `org.bytedeco` Java bindings for FFmpeg.
- Linked against `libavformat` for LCEVC muxing support in x264 flow.

---

# Implementation Details

## Mediacodec 
- Encoding via LCEVC Mediacodec SDK. 
- Muxing handled via the MediaMuxer API.

## x264
- Encoding via LCEVC x264 SDK.
- Muxing via `libavformat` (FFmpeg), enabling LCEVC side data injection.

---

# Test Configuration (Protobuf)

Added protobuf test configurations for both `mediacodec_h264` and `x264` encoders.

### Mediacodec H264 Example

```
test {
    input {
        filepath: "input.y4m"
    }
    common {
        id: "lcevc_mediacodec"
        description: "V-Nova's LCEVC Mediacodec H264 encoding"
    }
    configure {
        codec: "lcevc_h264"
        bitrate: "500 kbps"
        framerate: 30
        i_frame_interval: 3
        parameter {
            key: "base_encoder"
            type: stringType
            value: "mediacodec_h264"
        }
    }
}
```
### x264 Example

```
test {
    input {
        filepath: "input.y4m"
    }
    common {
        id: "lcevc_x264"
        description: "V-Nova's LCEVC x264 encoding"
    }
    configure {
        codec: "lcevc_h264"
        bitrate: "500 kbps"
        framerate: 30
        i_frame_interval: 10
        parameter {
            key: "base_encoder"
            type: stringType
            value: "x264"
        }
    }
}
```

# Running LCEVC Encodes

Added `--lcevc` flag to the encoding script to validate the protobuf test configuration for LCEVC and trigger the LCEVC encoding pipeline.
```./scripts/encapp.py run tests/lcevc_x264.pbtxt --lcevc```

