### PR TITLE
encapp: fix bitwise & used instead of logical && in boolean condition

### DIFF
--- a/app/src/main/java/com/facebook/encapp/Encoder.java
+++ b/app/src/main/java/com/facebook/encapp/Encoder.java
@@ -224,7 +224,7 @@ public abstract class Encoder {
         }
 
         mStats.setEncodedfile(mFilename);
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q & encoder != null) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q && encoder != null) {
             mStats.setEncoderIsHardwareAccelerated(encoder.getCodecInfo().isHardwareAccelerated());
         }
         return mMuxer;


### PR DESCRIPTION
Replace bitwise & with logical && in Encoder.java:227. The bitwise operator does not short-circuit, so both operands are always evaluated even when the first is false.